### PR TITLE
Revise story-events to enhance lowpop gameplay

### DIFF
--- a/code/game/gamemodes/events/grid_check.dm
+++ b/code/game/gamemodes/events/grid_check.dm
@@ -15,7 +15,7 @@ So sometimes this event can result in people finding new and interesting things
 	event_type = /datum/event/grid_check
 	event_pools = list(EVENT_LEVEL_MUNDANE = POOL_THRESHOLD_MUNDANE,
 	EVENT_LEVEL_MODERATE = POOL_THRESHOLD_MODERATE)
-	weight = 0.5 //Make this less common since its very long lasting
+	weight = 0.4 //Make this less common since its very long lasting
 
 	tags = list(TAG_SCARY, TAG_COMMUNAL)
 
@@ -42,12 +42,12 @@ So sometimes this event can result in people finding new and interesting things
 
 	for(var/obj/machinery/power/smes/buildable/S in SSmachines.machinery)
 		if (is_valid_smes(S))
-			S.energy_fail(rand(30 * severity*severity,40 * severity*severity))
+			S.energy_fail(rand(30 * severity,40 * severity))
 
 
 	for(var/obj/machinery/power/apc/C in SSmachines.machinery)
 		if(is_valid_apc(C) && (!affected_z_levels || (C.z in affected_z_levels)))
-			C.energy_fail(rand(90 * severity*severity,200 * severity*severity))
+			C.energy_fail(rand(90 * severity,200 * severity))
 
 /proc/power_restore(var/announce = 1)
 	var/list/skipped_areas = list(/area/turret_protected/ai)

--- a/code/game/gamemodes/events/infestation.dm
+++ b/code/game/gamemodes/events/infestation.dm
@@ -47,18 +47,12 @@ It focuses on spawning large numbers of moderate-to-weak monsters, and includes 
 	var/list/chosen_mob_classification = list()
 	var/list/possible_mobs_mundane = list(
 		INFESTATION_MICE = 17,
-		INFESTATION_LIZARDS = 12,
 		INFESTATION_SPIDERLINGS = 8,
-		INFESTATION_YITHIAN = 6,
-		INFESTATION_TINDALOS = 6,
-		INFESTATION_DIYAAB = 6,
 		INFESTATION_SPACE_BATS = 7
 	)
 
 	var/possible_mobs_moderate = list(
 		INFESTATION_SPACE_BATS = 10,
-		INFESTATION_SAMAK = 5,
-		INFESTATION_SHANTAK = 7,
 		INFESTATION_SPIDERS = 7,//This is a combination of spiderlings and adult spiders
 		INFESTATION_ROACHES = 7
 	)

--- a/code/game/gamemodes/events/spacevine.dm
+++ b/code/game/gamemodes/events/spacevine.dm
@@ -8,6 +8,7 @@
 	id = "spacevine"
 	name = "rampant flora"
 
+	enabled = FALSE
 
 	event_type = /datum/event/spacevine
 	event_pools = list(EVENT_LEVEL_MAJOR = POOL_THRESHOLD_MAJOR*0.6)

--- a/code/game/gamemodes/events/wallrot.dm
+++ b/code/game/gamemodes/events/wallrot.dm
@@ -9,6 +9,7 @@
 	id = "wallrot"
 	name = "wallrot"
 
+	enabled = FALSE
 
 	event_type = /datum/event/wallrot
 	event_pools = list(EVENT_LEVEL_MUNDANE = POOL_THRESHOLD_MUNDANE *0.8)


### PR DESCRIPTION
## About The Pull Request

Revise storyevents by disabling them from being picked for normal gameplay, and altering the weight of others.

## Why It's Good For The Game

It's requested by the community. And it does enhance the gameplay, specially considered that the population is too low

## Changelog
:cl:
tweak: Limited creature candidates for the infestation event (now it's just mice, spiders, bats, spiders, and slimes)
balance: Disabled "spacevine" event
balance: Disabled "wallrot" event
balance: Lowered "grid_check" event weight lowered the maximum failure time from 1600 seconds down to 800 seconds for APCs. SMES' failure times are lot lower.
/:cl:
