### PR TITLE
Nuke hunger slowdown out of existence

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -21,8 +21,6 @@
 		tally -= 0.5
 
 	var/health_deficiency = (maxHealth - health)
-	var/hunger_deficiency = (max_nutrition - nutrition) //400 = max for humans.
-	if(hunger_deficiency >= 200) tally += (hunger_deficiency / 100) //If youre starving, movement slowdown can be anything up to 4.
 	if(health_deficiency >= 40) tally += (health_deficiency / 25)
 
 	if (!(species && (species.flags & NO_PAIN)))


### PR DESCRIPTION
## About The Pull Request

Ahah movement slowdown by hunger go booooom.

## Why It's Good For The Game

Community demand. And people no longer are threatened by another incessant factor hampering their ability to regenerate their well-being when hungry.

## Changelog
```changelog
del: Movement is no longer affected by hunger
```