### PR TITLE
Increase overall limit of languages; 2 -> 3

### DIFF
--- a/code/modules/client/preference_setup/background/02_language.dm
+++ b/code/modules/client/preference_setup/background/02_language.dm
@@ -1,4 +1,4 @@
-#define MAX_LANGUAGES 2
+#define MAX_LANGUAGES 3
 
 /datum/preferences
 	var/list/alternate_languages


### PR DESCRIPTION
## About The Pull Request

Increase the `MAX_LANGUAGES` macro to 3.

## Why It's Good For The Game

Community demand. It will also help against insular IC meta-cliques in the future. Specially considered the *extremely* diverse selection of languages. 

## Changelog
```changelog
tweak: Language limit increased from 2 to 3
```
