### PR TITLE
Change overcoats to storage subtypes

### DIFF
--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -15,7 +15,7 @@
 	name = OUTFIT_JOB_NAME("Ironhammer Commander")
 	l_ear = /obj/item/device/radio/headset/heads/hos
 	uniform = /obj/item/clothing/under/rank/ih_commander
-	suit = /obj/item/clothing/suit/armor/greatcoat/ironhammer
+	suit = /obj/item/clothing/suit/storage/greatcoat/ironhammer
 	l_pocket = /obj/item/device/flash
 	gloves = /obj/item/clothing/gloves/stungloves
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud/tactical

--- a/code/game/objects/items/weapons/storage/deferred.dm
+++ b/code/game/objects/items/weapons/storage/deferred.dm
@@ -258,7 +258,7 @@
 	/obj/item/clothing/head/armor/altyn/brown = 1,
 	/obj/item/clothing/mask/balaclava/tactical = 1,
 	/obj/item/clothing/shoes/jackboots = 1,
-	/obj/item/clothing/suit/armor/greatcoat/serbian_overcoat_brown = 1)
+	/obj/item/clothing/suit/storage/greatcoat/serbian_overcoat_brown = 1)
 
 /obj/item/weapon/storage/deferred/crate/uniform_black
 	name = "black uniform kit"
@@ -271,7 +271,7 @@
 	/obj/item/clothing/mask/balaclava/tactical = 1,
 	/obj/item/clothing/shoes/jackboots = 1,
 	/obj/item/clothing/gloves/fingerless = 1,
-	/obj/item/clothing/suit/armor/greatcoat/serbian_overcoat = 1)
+	/obj/item/clothing/suit/storage/greatcoat/serbian_overcoat = 1)
 
 /obj/item/weapon/storage/deferred/crate/uniform_flak
 	name = "flak serbian uniform crate"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -62,7 +62,7 @@
 	new /obj/item/clothing/head/beret/sec/navy/hos(src)
 	new /obj/item/clothing/head/HoS(src)
 	new /obj/item/clothing/mask/gas/ihs(src)
-	new /obj/item/clothing/suit/armor/greatcoat/ironhammer(src)
+	new /obj/item/clothing/suit/storage/greatcoat/ironhammer(src)
 	new /obj/item/clothing/under/rank/ih_commander(src)
 	new /obj/item/device/radio/headset/heads/hos(src)
 	new /obj/item/clothing/glasses/sunglasses/sechud/tactical(src)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -62,37 +62,6 @@
 	)
 	price_tag = 150
 
-/obj/item/clothing/suit/armor/greatcoat
-	name = "armored coat"
-	desc = "A greatcoat enhanced with a special alloy for some protection and style."
-	icon_state = "greatcoat"
-	item_state = "hos"
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
-	armor = list(
-		melee = 30,
-		bullet = 35,
-		energy = 30,
-		bomb = 15,
-		bio = 0,
-		rad = 0
-	)
-	price_tag = 600
-
-/obj/item/clothing/suit/armor/greatcoat/ironhammer
-	icon_state = "greatcoat_ironhammer"
-
-/obj/item/clothing/suit/armor/greatcoat/serbian_overcoat
-	name = "black serbian overcoat"
-	desc = "A black serbian overcoat with armor-weave and rank epaulettes"
-	icon_state = "overcoat_black"
-	item_state = "overcoat_black"
-
-/obj/item/clothing/suit/armor/greatcoat/serbian_overcoat_brown
-	name = "brown serbian overcoat"
-	desc = "A brown serbian overcoat with armor-weave and rank epaulettes"
-	icon_state = "overcoat_brown"
-	item_state = "overcoat_brown"
-
 // Serbian flak vests
 /obj/item/clothing/suit/armor/flak
 	name = "black flakvest"
@@ -333,6 +302,44 @@
 	siemens_coefficient = 0
 	price_tag = 600
 	//Used ablative gear armor values and technomancer helmet/voidsuit values.
+
+// Great-/overcoats retyped from armor to storage
+/obj/item/clothing/suit/storage/greatcoat
+	name = "armored coat"
+	desc = "A greatcoat enhanced with a special alloy for some protection and style."
+	icon_state = "greatcoat"
+	item_state = "hos"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
+	item_flags = THICKMATERIAL|DRAG_AND_DROP_UNEQUIP
+	cold_protection = UPPER_TORSO|LOWER_TORSO
+	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
+	heat_protection = UPPER_TORSO|LOWER_TORSO
+	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
+	siemens_coefficient = 0.6
+	armor = list(
+		melee = 30,
+		bullet = 35,
+		energy = 30,
+		bomb = 15,
+		bio = 0,
+		rad = 0
+	)
+	price_tag = 600
+
+/obj/item/clothing/suit/storage/greatcoat/ironhammer
+	icon_state = "greatcoat_ironhammer"
+
+/obj/item/clothing/suit/storage/greatcoat/serbian_overcoat
+	name = "black serbian overcoat"
+	desc = "A black serbian overcoat with armor-weave and rank epaulettes"
+	icon_state = "overcoat_black"
+	item_state = "overcoat_black"
+
+/obj/item/clothing/suit/storage/greatcoat/serbian_overcoat_brown
+	name = "brown serbian overcoat"
+	desc = "A brown serbian overcoat with armor-weave and rank epaulettes"
+	icon_state = "overcoat_brown"
+	item_state = "overcoat_brown"
 
 /*
  * Reactive Armor

--- a/code/modules/stashes/stash_types/captain.dm
+++ b/code/modules/stashes/stash_types/captain.dm
@@ -31,7 +31,7 @@
 	/obj/item/weapon/hatton = 15,
 	/obj/item/weapon/rcd = 15,
 	/obj/item/weapon/melee/telebaton = 15,
-	/obj/item/clothing/suit/armor/greatcoat = 15)
+	/obj/item/clothing/suit/storage/greatcoat = 15)
 	weight = 0.2
 
 


### PR DESCRIPTION
## About The Pull Request

Greatcoats and overcoats had their parent type changed from `obj/item/clothing/suit/armor` to `obj/item/clothing/suit/storage`. A refactor necessary to add pockets/storage to them.

## Why It's Good For The Game

Greatcoats and overcoats now have pockets, how great is that?!?!

## Changelog
```changelog
add: Great-/overcoats now have pocket-like storage
refactor: Great-/overcoats changed from `armor` subtypes to `storage`
```