### PR TITLE
Clean-up unused languages and bloat

### DIFF
--- a/code/__DEFINES/species_languages.dm
+++ b/code/__DEFINES/species_languages.dm
@@ -44,28 +44,16 @@
 #define NO_STUTTER   256 // No stuttering, slurring, or other speech problems
 
 // Languages.
-#define LANGUAGE_GALCOM "Galactic Common"
-#define LANGUAGE_EAL "Encoded Audio Language"
 #define LANGUAGE_SOL_COMMON "Sol Common"
 #define LANGUAGE_UNATHI "Sinta'unathi"
 #define LANGUAGE_SIIK "Siik"
 #define LANGUAGE_SKRELLIAN "Common Skrellian"
-#define LANGUAGE_TRADEBAND "Tradeband"
-#define LANGUAGE_GUTTER "Gutter"
-#define LANGUAGE_SIGN "Sign Language"
 #define LANGUAGE_SCHECHI "Schechi"
 #define LANGUAGE_ROOTLOCAL "Local Rootspeak"
 #define LANGUAGE_ROOTGLOBAL "Global Rootspeak"
 #define LANGUAGE_YUELDISCH "Yueldisch"
 #define LANGUAGE_VOX "Vox-Pidgin"
-#define LANGUAGE_TERMINUS "Terminus"
-#define LANGUAGE_SKRELLIANFAR "High Skrellian"
-#define LANGUAGE_MINBUS "Minbus"
-#define LANGUAGE_EVENT1 "Occursus"
-#define LANGUAGE_LANIUS "Scraptalk"
 #define LANGUAGE_AKHANI "Akhani"
-#define LANGUAGE_ALAI "Alai"
-#define LANGUAGE_BIRDSONG "Birdsong"
 #define LANGUAGE_SAGARU "Sagaru"
 
 // Species flags.

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -74,7 +74,7 @@
 		if(stash.stash_location)
 			choices += CHOICE_STASHPAPER
 	// Let's see if an additional language is feasible. If the user has them all already somehow, we aren't gonna choose this.
-	var/list/valid_languages = list(LANGUAGE_COMMON, LANGUAGE_JIVE, LANGUAGE_UNATHI, LANGUAGE_SIIK, LANGUAGE_SKRELLIAN, LANGUAGE_TRADEBAND, LANGUAGE_GUTTER, LANGUAGE_SCHECHI, LANGUAGE_BIRDSONG) // Not static, because we're gonna remove languages already known by the user
+	var/list/valid_languages = list(LANGUAGE_COMMON, LANGUAGE_JIVE, LANGUAGE_UNATHI, LANGUAGE_SIIK, LANGUAGE_SKRELLIAN, LANGUAGE_SCHECHI) // Not static, because we're gonna remove languages already known by the user
 	for(var/l in valid_languages)
 		var/datum/language/L = all_languages[l]
 		if(L in holder.languages)

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -180,20 +180,6 @@
 	flags = WHITELISTED
 	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix")
 
-/datum/language/skrellfar
-	name = LANGUAGE_SKRELLIANFAR
-	desc = "The most common language among the Skrellian Far Kingdoms. Has an even higher than usual concentration of inaudible phonemes."
-	speech_verb = "warbles"
-	ask_verb = "warbles"
-	exclaim_verb = "sings"
-	whisper_verb = "hums"
-	colour = "skrellfar"
-	key = "p"
-	space_chance = 30
-	flags = WHITELISTED
-	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix", "...", "oo", "q", "nq", "x", "xq", "ll", "...", "...", "...") //should sound like there's holes in it
-
-
 /datum/language/human
 	name = LANGUAGE_SOL_COMMON
 	desc = "A bastardized hybrid of many languages, including Chinese, English, French, and more; it is the common language of the Sol system."
@@ -233,14 +219,6 @@
 	"ist","ein","entch","zwichs","tut","mir","wo","bis","es","vor","nic","gro","lll","enem","zandt","tzch","noch", \
 	"hel","ischt","far","wa","baram","iereng","tech","lach","sam","mak","lich","gen","or","ag","eck","gec","stag","onn", \
 	"bin","ket","jarl","vulf","einech","cresthz","azunein","ghzth")
-
-/datum/language/birdsong
-	name = LANGUAGE_BIRDSONG
-	desc = "A language primarily spoken by Nevreans"
-	speech_verb = "chirps"
-	colour = "birdsongc"
-	key = "7"
-	syllables = list ("cheep", "peep", "tweet")
 
 /datum/language/sergal
 	name = LANGUAGE_SAGARU

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -157,7 +157,7 @@
 //	metabolic_rate = 1.1
 	gluttonous = 1
 	num_alternate_languages = 3
-	secondary_langs = list(LANGUAGE_SIIK, LANGUAGE_AKHANI, LANGUAGE_ALAI)
+	secondary_langs = list(LANGUAGE_SIIK, LANGUAGE_AKHANI)
 	name_language = LANGUAGE_SIIK
 //	species_language = LANGUAGE_SIIK
 //	health_hud_intensity = 2.5

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -157,8 +157,7 @@
 //	icobase_tail = 1
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	num_alternate_languages = 3
-	secondary_langs = list(LANGUAGE_TERMINUS)
-	name_language = LANGUAGE_TERMINUS
+	secondary_langs = list()
 //	assisted_langs = list(LANGUAGE_EAL, LANGUAGE_SKRELLIAN, LANGUAGE_SKRELLIANFAR, LANGUAGE_ROOTLOCAL, LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX)	//Eclipse edit: Zorren can speak Terminus unassisted.
 
 	min_age = 18
@@ -197,8 +196,7 @@
 //	icobase_tail = 1
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	num_alternate_languages = 3
-	secondary_langs = list(LANGUAGE_TERMINUS)
-	name_language = LANGUAGE_TERMINUS
+	secondary_langs = list()
 //	assisted_langs = list(LANGUAGE_EAL, LANGUAGE_SKRELLIAN, LANGUAGE_SKRELLIANFAR, LANGUAGE_ROOTLOCAL, LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX)	//Eclipse edit: Zorren can speak Terminus unassisted.
 
 	min_age = 18


### PR DESCRIPTION
## About The Pull Request

Make the codebase and languages a bit more maintainable by removing languages and macros are not being used at all.

## Why It's Good For The Game

It won't affect the game much, and it's a quality of life for character creation to make the language picking less overwhelming and confusing.

## Changelog
```changelog
del: Removed some unused code related to languages
del: Removed following languages that had definitions: `Birdsong` and `High Skrellian`
```