### PR TITLE
Gloves now always protect against scrap cutting

### DIFF
--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -240,7 +240,7 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 		var/mob/living/carbon/human/victim = user
 		if(victim.species.flags & NO_MINOR_CUT)
 			return FALSE
-		if(victim.gloves && prob(90))
+		if(victim.gloves)
 			return FALSE
 		if(victim.wear_suit && istype(victim.wear_suit, /obj/item/clothing/suit/space)) //Eclipse edit: if getting cut through the spacesuit doesn't somehow depressurize it, then it should not cut you at all
 			return


### PR DESCRIPTION
## About The Pull Request

A probability check has been removed from the `hurt_hands` code of scrap piles. Having gloves *will always* protect from toxin injection.

## Why It's Good For The Game

Gameplay > realism. It's also a popular demand by the community.

## Changelog
```changelog
balance: Gloves now always will protect against cutting on scrap when rummaging in them
```
