### PR TITLE
Give Moebius RD access to AI Private channel

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -100,7 +100,7 @@
 /obj/item/device/encryptionkey/heads/cmo
 	name = "chief medical officer's encryption key"
 	icon_state = "cmo_cypherkey"
-	channels = list("Medical" = 1, "Command" = 1)
+	channels = list("Science" = 1, "Medical" = 1, "Command" = 1)
 
 /obj/item/device/encryptionkey/heads/hop
 	name = "head of personnel's encryption key"

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -85,7 +85,7 @@
 /obj/item/device/encryptionkey/heads/moebius
 	name = "\improper NanoTrasen command encryption key"
 	icon_state = "rd_cypherkey"
-	channels = list("Science" = 1, "Medical" = 1, "Command" = 1)
+	channels = list("Science" = 1, "Medical" = 1, "Command" = 1, "AI Private" = 1)
 
 /obj/item/device/encryptionkey/heads/hos
 	name = "aegis commander's encryption key"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -165,7 +165,7 @@
 	desc = "The headset of the highly trained medical chief."
 	icon_state = "com_headset"
 	item_state = "headset"
-	ks2type = /obj/item/device/encryptionkey/heads/moebius
+	ks2type = /obj/item/device/encryptionkey/heads/cmo
 
 /obj/item/device/radio/headset/heads/hop
 	name = "head of personnel's headset"


### PR DESCRIPTION
## About The Pull Request

A requested change. Because it makes sense if you consider the fact they are in charge of making sure the AI is alright.

## Why It's Good For The Game

Requested change.

## Changelog
```changelog
tweak: Gave the RD's headset access to the `AI Private` channel
fix: The CMO's headset now have their own encryption key to differentiate from RD's headset.
```
