### PR TITLE
Add ventcrawl to all drones

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -178,7 +178,7 @@
 
 /mob/living/silicon/robot/AltClickOn(var/atom/A)
 	if(ai_access)
-		return A.BorgAltClick(src)
+		A.BorgAltClick(src)
 	..()
 
 /atom/proc/BorgCtrlShiftClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
@@ -207,7 +207,6 @@
 
 /atom/proc/BorgAltClick(var/mob/living/silicon/robot/user)
 	AltClick(user)
-	return
 
 /obj/machinery/door/airlock/BorgAltClick(var/mob/living/silicon/robot/user) // Eletrifies doors. Forwards to AI code.
 	AIAltClick(user)

--- a/code/modules/mob/living/silicon/robot/drone/_drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/_drone.dm
@@ -108,6 +108,9 @@ var/list/mob_hat_cache = list()
 	can_pull_size = ITEM_SIZE_HUGE
 	can_pull_mobs = MOB_PULL_SAME
 
+/mob/living/silicon/robot/drone/is_allowed_vent_crawl_item()
+	return TRUE
+
 /mob/living/silicon/robot/drone/New()
 
 	..()
@@ -116,6 +119,8 @@ var/list/mob_hat_cache = list()
 	if(!module) module = new module_type(src)
 
 	verbs += /mob/living/proc/hide
+	verbs += /mob/living/proc/ventcrawl
+
 	remove_language(LANGUAGE_ROBOT)
 	add_language(LANGUAGE_ROBOT, 0)
 	add_language(LANGUAGE_DRONE, 1)


### PR DESCRIPTION
## About The Pull Request

Drones now have ventcrawl. And alt-clicking is no longer blocked by a rather ill-advised flow control exclusive to all robots (cyborgs and drones).

## Why It's Good For The Game

It gives the drones more mobility. It's also a requested change.

## Changelog
```changelog
add: Drones (maintenance, construction, and biltzshell) now have the ability to ventcrawl.
fix: Alt-clicking for robots; including cyborgs and drones, had incorrect flow. It now will activate ventcrawl if they have the ability to.
```