### PR TITLE
Adjust respawn delays & fix observer warning

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -147,8 +147,8 @@
 #define ANIMAL	"animal"//Used for mice and any other simple animals
 #define MINISYNTH	"minisynth"//Used for drones and pAIs
 
-#define ANIMAL_SPAWN_DELAY 5 MINUTES
-#define DRONE_SPAWN_DELAY  10 MINUTES
+#define ANIMAL_SPAWN_DELAY 2 MINUTES
+#define DRONE_SPAWN_DELAY  3 MINUTES
 
 #define CRYOPOD_SPAWN_BONUS	20 MINUTES//Going to sleep in a cryopod takes this much off your respawn time in minutes
 #define CRYOPOD_SPAWN_BONUS_DESC	"20 minutes"	//Tells players how long they have until respawn.

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -144,7 +144,7 @@
 
 	if(href_list["observe"])
 
-		if(alert(src,"Are you sure you wish to observe? You will have to wait 30 minutes before being able join the crew! But you can play as a mouse or drone immediately.","Player Setup","Yes","No") == "Yes")
+		if(alert(src,"Are you sure you wish to observe? You will have to wait [config.respawn_delay] before being able join the crew! But you can play as a mouse or drone immediately.","Player Setup","Yes","No") == "Yes")
 			if(!client)	return 1
 			var/mob/observer/ghost/observer = new()
 


### PR DESCRIPTION
## About The Pull Request

Less waiting games and more actual action games. It also fixes the observer warning, when clicking on it from the lobby screen, always displaying "30 minutes" regardless of the actual value set in configuration.

## Why It's Good For The Game

Makes the SS13 less of a waiting game.

## Changelog
```changelog
balance: Ghost -> Mob spawn delay changed from 5 to 2 minutes
balance: Ghost -> Drone spawn delay changed from 10 to 3 minutes
fix: The warning displayed when clicking on lobby's Observe button now show the actual delay as set by the configuration
```