### PR TITLE
Autoinjector Alterations

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -90,11 +90,11 @@
 	slot_flags = SLOT_EARS
 	icon_state = "autoinjector"
 	item_state = "autoinjector"
-	amount_per_transfer_from_this = 5
+	amount_per_transfer_from_this = 10
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1)
 	reagent_flags = REFILLABLE | DRAINABLE | AMOUNT_VISIBLE
-	volume = 5
-	preloaded_reagents = list("inaprovaline" = 5)
+	volume = 10
+	preloaded_reagents = list("inaprovaline" = 10)
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/on_reagent_change()
 	..()
@@ -114,15 +114,15 @@
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/antitoxin
 	name = "autoinjector (anti-toxin)"
-	preloaded_reagents = list("anti_toxin" = 5)
+	preloaded_reagents = list("anti_toxin" = 10)
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/tricordrazine
 	name = "autoinjector (tricordrazine)"
-	preloaded_reagents = list("tricordrazine" = 5)
+	preloaded_reagents = list("tricordrazine" = 10)
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/spaceacillin
 	name = "autoinjector (spaceacillin)"
-	preloaded_reagents = list("spaceacillin" = 5)
+	preloaded_reagents = list("spaceacillin" = 10)
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/hyperzine
 	name = "autoinjector (hyperzine)"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -115,7 +115,7 @@
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/empty
 	name = "autoinjector"
 	preloaded_reagents = list("inaprovaline" = 0)
-	#Yes I know this is stupid, but it's a lot easier than making the parent empty and fixing all the fallout from that for now.
+//Yes I know this is stupid, but it's a lot easier than making the parent empty and fixing all the fallout from that for now.'
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/antitoxin
 	name = "autoinjector (anti-toxin)"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -112,6 +112,11 @@
 		icon_state = "[initial(icon_state)]0"
 
 
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/empty
+	name = "autoinjector"
+	preloaded_reagents = list("inaprovaline" = 0)
+	#Yes I know this is stupid, but it's a lot easier than making the parent empty and fixing all the fallout from that for now.
+
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/antitoxin
 	name = "autoinjector (anti-toxin)"
 	preloaded_reagents = list("anti_toxin" = 10)
@@ -129,5 +134,5 @@
 	preloaded_reagents = list("hyperzine" = 5)
 
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/drugs
-	name = "autoinjector (drugs)"
-	preloaded_reagents = list("space_drugs" = 5)
+	name = "autoinjector (sedative)"
+	preloaded_reagents = list("tramadol" = 2.5, "mindwipe" = 1, "stoxin" = 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs autoinjectors.

## Why It's Good For The Game

Autoinjectors were basically unused, this makes them viable in niche situations over syringes.

## Changelog
```changelog
add: empty autoinjectors

tweak: autoinjectors now hold/mostly come with 10 units of reagents.
tweak: 'autoinjector/drugs' now displays as 'autoinjector (sedative)'
tweak: 'autoinjector/drugs' now contains sedatives

```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
