### PR TITLE
Add Brig access to Aegis Medical Specialist

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -188,7 +188,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/security/medspec
 
 	access = list(
-		access_security, access_moebius, access_sec_doors, access_medspec, access_morgue, access_maint_tunnels, access_medical_equip
+		access_security, access_brig, access_moebius, access_sec_doors, access_medspec, access_morgue, access_maint_tunnels, access_medical_equip
 	)
 
 	stat_modifiers = list(


### PR DESCRIPTION
## About The Pull Request

Add `access_brig = 2` to the Aegis Medical Specialist's list of access. Allowing them entry into the holding cells and the permabrig.

## Why It's Good For The Game

Requested by community

## Changelog
```changelog
fix: Aegis Medical Specialist now has access to the permabrig & holding cells
```
