### PR TITLE
Add flare to survival boxes

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -94,12 +94,14 @@
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/weapon/tank/emergency_oxygen(src)
 	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/device/lighting/glowstick/flare(src)
 
 /obj/item/weapon/storage/box/survival/extended/populate_contents()
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/weapon/tank/emergency_oxygen/engi(src)
 	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
 	new /obj/item/device/lighting/glowstick/yellow(src)
+	new /obj/item/device/lighting/glowstick/flare(src)
 
 /obj/item/weapon/storage/box/gloves
 	name = "box of latex gloves"


### PR DESCRIPTION
## About The Pull Request

Adds the flare (`/obj/item/device/lighting/glowstick/flare`) to the survival boxes both the normal and the extended variant.

## Why It's Good For The Game

Requested by community.

## Changelog
```changelog
add: Added flare to survival boxes
```
