### PR TITLE
tweak job locker contents

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -113,6 +113,7 @@
 	new /obj/item/weapon/reagent_containers/hypospray(src)
 	new /obj/item/weapon/storage/belt/medical(src)
 	new /obj/item/weapon/storage/pouch/medical_supply(src)
+	new /obj/item/weapon/reagent_containers/hypospray/autoinjector/drugs(src)
 
 /obj/structure/closet/secure_closet/animal
 	name = "animal control closet"
@@ -133,6 +134,7 @@
 	req_access = list(access_chemistry)
 
 /obj/structure/closet/secure_closet/chemical/populate_contents()
-	new /obj/item/weapon/storage/box/pillbottles(src)
-	new /obj/item/weapon/storage/box/pillbottles(src)
 	new /obj/item/weapon/storage/pouch/tubular/vial(src)
+	new /obj/item/weapon/storage/pouch/tubular/vial(src)
+	new /obj/item/weapon/storage/box/autoinjectors/empty(src)
+	new /obj/item/weapon/storage/box/autoinjectors/empty(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -158,6 +158,7 @@
 	new /obj/item/weapon/gun/projectile/automatic/molly(src)
 	new /obj/item/weapon/storage/pouch/pistol_holster(src)
 	new /obj/item/weapon/storage/briefcase/crimekit(src)
+	new /obj/item/weapon/storage/box/autoinjectors/tricordrazine(src)
 
 /obj/structure/closet/secure_closet/detective
 	name = "Cobalt Inspector locker"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tweaks job locker contents.

## Why It's Good For The Game

Expands options for Pharmacist 'products', gives Aegis Medical Specialist more appropriate medical supplies, equips CMO to handle mental breaks.

## Changelog
```changelog
add: Box of tricord injectors in Aegis Medical Specialist's lockers
add: 2 boxes of empty injectors in chemistry locker
add: Extra vial pouch in chemistry locker
add: Sedative injector in CMO's locker
del: Redundant pill bottles in chemistry locker
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
