### PR TITLE
Fix multi-z falling and catwalks

### DIFF
--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -10,9 +10,6 @@
 
 /obj/structure/catwalk/New()
 	..()
-	if (istype(loc, /turf/simulated/open))
-		var/turf/simulated/open/T = loc
-		T.updateFallability()
 	spawn(4)
 		if(src)
 			for(var/obj/structure/catwalk/C in get_turf(src))
@@ -20,6 +17,10 @@
 					qdel(C)
 			update_icon()
 			redraw_nearby_catwalks()
+
+			if (istype(loc, /turf/simulated/open))
+				var/turf/simulated/open/T = loc
+				T.updateFallability()
 
 /obj/structure/catwalk/Destroy()
 	if (istype(loc, /turf/simulated/open))
@@ -82,5 +83,7 @@
 	return
 
 
+// Can it prevent falling from the z-level above? Enables "hovering" in the z-level
+// above if TRUE
 /obj/structure/catwalk/can_prevent_fall()
-	return TRUE
+	return FALSE

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -71,7 +71,7 @@
 	
 	if(istype(loc, /turf/simulated/open))
 		var/turf/simulated/open/open = loc
-		open.fallThrough(src)
+		open.Entered(src)
 
 // If we have opacity, make sure to tell (potentially) affected light sources.
 /atom/movable/Destroy()

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -87,7 +87,8 @@ see multiz/movement.dm for some info.
 		if(!below)
 			return
 
-	if(locate(/obj/structure/catwalk) in src)
+	var/obj/structure/catwalk/CAT = (locate(/obj/structure/catwalk) in src)
+	if(CAT && !CAT.gc_destroyed)
 		return
 
 	if(locate(/obj/structure/multiz/stairs) in src)


### PR DESCRIPTION
## About The Pull Request

An alternative implementation of the https://github.com/discordia-space/CEV-Eris/issues/5109 fix https://github.com/discordia-space/CEV-Eris/pull/5196

## Why It's Good For The Game

Fixes https://github.com/discordia-space/CEV-Eris/issues/5109
Fixes https://github.com/SyzygyStation/Syzygy-Eris/issues/22

## Changelog
```changelog
fix: Atoms no longer fall through catwalks when they are spawned ontop of catwalks
fix: Catwalks no longer block falling from the z-level above them
fix: Open spaces now properly update when catwalks have been removed
```