### PR TITLE
Syzygy - Hivemind Bomber Probe Nerf

### DIFF
--- a/code/modules/hivemind/mobs.dm
+++ b/code/modules/hivemind/mobs.dm
@@ -278,6 +278,7 @@
 	mob_size = MOB_SMALL
 	pass_flags = PASSTABLE
 	speed = 6
+	move_to_delay = 10//Syzygy edit
 
 	speak = list(
 				"WE COME IN PEACE.",
@@ -302,11 +303,18 @@
 /mob/living/simple_animal/hostile/hivemind/bomber/death()
 	..()
 	gibs(loc, null, /obj/effect/gibspawner/robot)
-	explosion(get_turf(src), 0, 0, 2)
 	qdel(src)
 
 
 /mob/living/simple_animal/hostile/hivemind/bomber/AttackingTarget()
+	//Syzygy edit start
+	playsound(src, 'sound/effects/scanbeep.ogg', 100, 1)
+	src.visible_message(SPAN_DANGER("Smoke pours out of [src]!"))
+	set_light(7, 2, "#FF4411")
+	move_to_delay = 60
+	sleep(30)
+	explosion(get_turf(src), 0, 0, 2)
+	//Syzygy edit end
 	death()
 
 


### PR DESCRIPTION
## About The Pull Request

Several balance tweaks to the Hivemind bomber probes.

- Probes now only explode when attacking a mob, not on death.
- Reduces their maximum health (may need to tweak malfunction chance in a follow-up in case they die too much)
- Increases their base move_to_delay.
- Attacking makes a noise, a visible announce, and makes the probe glow ominously.
- Further increased move_to_delay when they begin an attack, to allow players to escape their janky simple animal movement.

## Why It's Good For The Game

Hivemind probes are the most dangerous hivemind mob by far. They still have the potential to do the most damage, but now they aren't as fast and players should have a better chance of being able to react to them.

## Changelog
```changelog
balance: reduced hivemind bomber health and speed, only explodes when attacking, gives more warning of attack.
```