### PR TITLE
Fix preferences-related runtimes

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -338,8 +338,7 @@
 		panel = null
 	user << browse(null, "window=saves")
 
-	var/mob/new_player/np = client.mob
-	np.new_player_panel_proc()			//Eclipse edit. Automatic refresh for current character.
+	try_refresh_lobby(user)
 
 /datum/preferences/proc/open_copy_dialog(mob/user)		//Eclipse edit.
 	var/dat = "<body>"
@@ -363,3 +362,9 @@
 	panel = new(user, "Character Slots", "Character Slots", 300, 390, src)
 	panel.set_content(dat)
 	panel.open()
+
+// Syzygy edit to fix an runtime casually caused by an Eclipse edit
+/datum/preferences/proc/try_refresh_lobby(mob/user = client.mob)
+	if (user && istype(user, /mob/new_player))
+		var/mob/new_player/np = user
+		np.new_player_panel_proc()			//Eclipse edit. Automatic refresh for current character.

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -84,10 +84,7 @@
 	player_setup.save_character(S)
 	loaded_character = S
 
-	// Syzygy edit to fix an runtime casually caused by an Eclipse edit
-	if (client.mob && istype(client.mob, /mob/new_player))
-		var/mob/new_player/np = client.mob
-		np.new_player_panel_proc()			//Eclipse edit. Automatic refresh for current character.
+	try_refresh_lobby(client.mob)
 
 	return S
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -84,8 +84,10 @@
 	player_setup.save_character(S)
 	loaded_character = S
 
-	var/mob/new_player/np = client.mob
-	np.new_player_panel_proc()			//Eclipse edit. Automatic refresh for current character.
+	// Syzygy edit to fix an runtime casually caused by an Eclipse edit
+	if (client.mob && istype(client.mob, /mob/new_player))
+		var/mob/new_player/np = client.mob
+		np.new_player_panel_proc()			//Eclipse edit. Automatic refresh for current character.
 
 	return S
 


### PR DESCRIPTION
## About The Pull Request

Fix a runtime as described in https://github.com/SyzygyStation/Syzygy-Eris/issues/54 and https://github.com/SyzygyStation/Syzygy-Eris/issues/72

## Why It's Good For The Game

Makes the game a bit more stable;
- Fixes https://github.com/SyzygyStation/Syzygy-Eris/issues/54 
- Fixes https://github.com/SyzygyStation/Syzygy-Eris/issues/72

## Changelog
```changelog
fix: Fixed a runtime caused by saving character preferences when not in lobby
```
