### PR TITLE
Refactor alt-click handling of vent-crawling

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -277,6 +277,7 @@
 /mob/proc/CtrlClickOn(var/atom/A)
 	A.CtrlClick(src)
 	return
+
 /atom/proc/CtrlClick(var/mob/user)
 	return
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -179,7 +179,8 @@
 /mob/living/silicon/robot/AltClickOn(var/atom/A)
 	if(ai_access)
 		A.BorgAltClick(src)
-	..()
+	else
+		..()
 
 /atom/proc/BorgCtrlShiftClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
 	CtrlShiftClick(user)

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -1,7 +1,14 @@
+// Entry-points that can be used to vent-crawl should be implemented like these:
 var/list/ventcrawl_machinery = list(
 	/obj/machinery/atmospherics/unary/vent_scrubber,
 	/obj/machinery/atmospherics/unary/vent_pump
 	)
+
+/obj/machinery/atmospherics/unary/vent_scrubber/AltClick(mob/living/user)
+	user.handle_ventcrawl(src)
+
+/obj/machinery/atmospherics/unary/vent_pump/AltClick(mob/living/user)
+	user.handle_ventcrawl(src)
 
 // Vent crawling whitelisted items, whoo
 // What are these for? Antags mostly,and allowing mice to steal small things
@@ -70,12 +77,6 @@ var/list/ventcrawl_machinery = list(
 			to_chat(src, "<span class='warning'>You can't carry \the [A] while ventcrawling!</span>")
 			return FALSE
 	return TRUE
-
-/mob/living/AltClickOn(var/atom/A)
-	if(is_type_in_list(A,ventcrawl_machinery))
-		handle_ventcrawl(A)
-		return 1
-	return ..()
 
 /mob/proc/start_ventcrawl()
 	var/atom/pipe
@@ -155,6 +156,7 @@ var/list/ventcrawl_machinery = list(
 			to_chat(src, "This vent is not connected to anything.")
 	else
 		to_chat(src, "You must be standing on or beside an air vent to enter it.")
+
 /mob/living/proc/add_ventcrawl(obj/machinery/atmospherics/starting_machine)
 
 	var/datum/pipe_network/network


### PR DESCRIPTION
## About The Pull Request

Removes an override of `AltClickOn` (mob function that calls `AltClick` of click target); moving the handling of vent-crawling into `AltClick` overrides of entry-points for ventcrawling.

## Why It's Good For The Game

Fixes https://github.com/SyzygyStation/Syzygy-Eris/issues/63

## Changelog
```changelog
fix: Fixed Alt-clicking being called twice for robot mobs; not showing users any Turf-tabs
refactor: Alt-clicking for vent-crawling is now handled by vents & scrubbers
```