### PR TITLE
Fix "gulp down" always succeeding when it should not

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -96,9 +96,9 @@
 		if(reagents.total_volume > 30) // 30 equates to 3 SECONDS.
 			usr.visible_message(SPAN_NOTICE("[usr] prepares to gulp down [src]."), SPAN_NOTICE("You prepare to gulp down [src]."))
 		if(!do_after(usr, reagents.total_volume))
-			if(!Adjacent(usr))
-				return
-			standard_splash_mob(src, src)
+			if(Adjacent(usr))
+				standard_splash_mob(src, src)
+			return
 
 		if(!Adjacent(usr))
 			return


### PR DESCRIPTION
## About The Pull Request

Fixes some ambiguous flow control that allows gulp-down to always succeed, when the conditions say otherwise

## Why It's Good For The Game

Fixes https://github.com/SyzygyStation/Syzygy-Eris/issues/42

## Changelog
```changelog
fix: Breaking the gulp-down wind-up now will splash on the mob and fail the act
```
