### PR TITLE
Fix runtime caused by gravity generator

### DIFF
--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -393,7 +393,7 @@ var/const/GRAV_NEEDS_WRENCH = 3
 /obj/machinery/gravity_generator/main/proc/shake_everyone()
 	for(var/mob/M in SSmobs.mob_list)
 		var/turf/our_turf = get_turf(src.loc)
-		if(M.client)
+		if(M.client && !istype(M, /mob/new_player))
 			shake_camera(M, 15, 1)
 			M.playsound_local(our_turf, 'sound/effects/alert.ogg', 100, 1, 0.5)
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/SyzygyStation/Syzygy-Eris/issues/56

## Why It's Good For The Game

Less clutter in the `View Runtimes` log, and makes it easier to pinpoint other problems.

## Changelog
```changelog
fix: Fixes gravity generator attempting to play the screen-shake effect to players sitting in lobby
```