### PR TITLE
Patch a leak over medical cloning room

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -38,8 +38,8 @@
 /area/eris/security/main)
 "aak" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-SW-out";
-	icon_state = "SW-out"
+	icon_state = "SW-out";
+	tag = "icon-SW-out"
 	},
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -311,8 +311,8 @@
 /area/eris/security/range)
 "aaW" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -430,9 +430,9 @@
 /area/eris/security/range)
 "abo" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
@@ -451,9 +451,9 @@
 /area/space)
 "abr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /turf/simulated/floor/plating/under,
@@ -470,17 +470,17 @@
 /area/eris/maintenance/section1deck5central)
 "abt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
 "abu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/plating/under,
@@ -619,9 +619,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -651,8 +651,8 @@
 /area/eris/crew_quarters/toilet/medbay)
 "abO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/range)
@@ -1019,14 +1019,14 @@
 /area/eris/crew_quarters/sleep)
 "acB" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (EAST)";
+	dir = 4;
 	icon_state = "pipe-u";
-	dir = 4
+	tag = "icon-pipe-u (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
@@ -1423,17 +1423,17 @@
 /area/eris/security/prison)
 "adw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/prison)
 "adx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1614,9 +1614,9 @@
 /area/eris/security/armory)
 "adU" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/camera/network/security,
 /obj/random/scrap/moderate_weighted/low_chance,
@@ -1639,9 +1639,9 @@
 /area/eris/security/prison)
 "adX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -1702,8 +1702,8 @@
 /area/eris/security/disposal)
 "aee" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/prison)
@@ -1958,9 +1958,9 @@
 /area/eris/security/prison)
 "aeM" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/security/disposal)
@@ -1992,9 +1992,9 @@
 /area/eris/security/armory)
 "aeR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2012,9 +2012,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2039,8 +2039,8 @@
 /area/eris/security/armory)
 "aeV" = (
 /obj/machinery/shower{
-	icon_state = "shower";
-	dir = 4
+	dir = 4;
+	icon_state = "shower"
 	},
 /obj/machinery/camera/network/prison,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -2064,9 +2064,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2081,9 +2081,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -2094,9 +2094,9 @@
 /area/eris/maintenance/section1deck5central)
 "afa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/wall,
 /area/eris/maintenance/section1deck5central)
@@ -2108,9 +2108,9 @@
 	dir = 4
 	},
 /obj/structure/disposaloutlet{
-	tag = "icon-outlet (WEST)";
+	dir = 8;
 	icon_state = "outlet";
-	dir = 8
+	tag = "icon-outlet (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/security/disposal)
@@ -2119,9 +2119,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/security/disposal)
@@ -2131,26 +2131,26 @@
 	icon_state = "pipe-y"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/security/disposal)
 "aff" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
 "afg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -2158,9 +2158,9 @@
 "afh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/structure/cable/green{
@@ -2172,9 +2172,9 @@
 /area/eris/maintenance/section1deck5central)
 "afi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/wall,
 /area/eris/maintenance/section1deck5central)
@@ -2190,8 +2190,8 @@
 /area/eris/maintenance/section1deck5central)
 "afk" = (
 /obj/machinery/shower{
-	icon_state = "shower";
-	dir = 8
+	dir = 8;
+	icon_state = "shower"
 	},
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -2248,9 +2248,9 @@
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck5starboard)
@@ -2409,17 +2409,17 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
 "afQ" = (
 /obj/machinery/shower{
-	icon_state = "shower";
-	dir = 4
+	dir = 4;
+	icon_state = "shower"
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/security/prison)
@@ -2451,8 +2451,8 @@
 /area/eris/security/disposal)
 "afW" = (
 /obj/machinery/shower{
-	icon_state = "shower";
-	dir = 8
+	dir = 8;
+	icon_state = "shower"
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/security/prison)
@@ -2586,15 +2586,15 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /obj/random/junk/low_chance,
@@ -2780,10 +2780,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2851,9 +2851,9 @@
 /area/eris/command/commander)
 "agM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck5starboard)
@@ -2879,17 +2879,17 @@
 /area/eris/maintenance/section1deck5central)
 "agP" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
 "agQ" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -2990,9 +2990,9 @@
 /area/space)
 "ahc" = (
 /obj/structure/disposaloutlet{
-	tag = "icon-outlet (WEST)";
+	dir = 8;
 	icon_state = "outlet";
-	dir = 8
+	tag = "icon-outlet (WEST)"
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -3004,9 +3004,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
@@ -3173,9 +3173,9 @@
 /area/eris/crew_quarters/sleep)
 "ahs" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3217,15 +3217,15 @@
 /area/eris/maintenance/section1deck5central)
 "ahx" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
@@ -3290,9 +3290,9 @@
 /area/eris/maintenance/section1deck5central)
 "ahJ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -3523,10 +3523,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3550,9 +3550,9 @@
 "air" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j2";
-	dir = 1
+	tag = "icon-pipe-j2 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -3569,9 +3569,9 @@
 /area/eris/maintenance/section1deck5central)
 "ais" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -3758,10 +3758,10 @@
 /area/eris/security/exerooms)
 "aiO" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3778,23 +3778,23 @@
 /area/eris/maintenance/section1deck5central)
 "aiQ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
 "aiR" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (EAST)";
+	dir = 4;
 	icon_state = "pipe-u";
-	dir = 4
+	tag = "icon-pipe-u (EAST)"
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -3812,10 +3812,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -3950,19 +3950,19 @@
 /area/eris/crew_quarters/sleep)
 "ajg" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
 "ajh" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -3988,8 +3988,8 @@
 	pixel_x = 24
 	},
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-21";
-	icon_state = "plant-21"
+	icon_state = "plant-21";
+	tag = "icon-plant-21"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/exerooms)
@@ -4077,9 +4077,9 @@
 /area/eris/crew_quarters/sleep)
 "ajr" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4149,9 +4149,9 @@
 /area/eris/security/exerooms)
 "ajA" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -4169,9 +4169,9 @@
 /area/eris/crew_quarters/sleep)
 "ajC" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -4195,9 +4195,9 @@
 /area/eris/security/exerooms)
 "ajE" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/junk/low_chance,
@@ -4265,9 +4265,9 @@
 /area/eris/maintenance/section1deck5central)
 "ajK" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -4303,9 +4303,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
@@ -4582,9 +4582,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -5002,8 +5002,8 @@
 	pixel_y = 0
 	},
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -5122,9 +5122,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -5153,9 +5153,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
@@ -5205,9 +5205,9 @@
 	},
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -5220,9 +5220,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -5422,9 +5422,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /turf/simulated/floor/plating/under,
@@ -5571,14 +5571,14 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -5666,9 +5666,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
@@ -5705,20 +5705,20 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
@@ -5792,31 +5792,31 @@
 /area/eris/hallway/side/eschangarb)
 "ani" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "anj" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "ank" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (NORTH)";
+	dir = 1;
 	icon_state = "pipe-u";
-	dir = 1
+	tag = "icon-pipe-u (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
@@ -5831,15 +5831,15 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
@@ -5850,15 +5850,15 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -5870,15 +5870,15 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -5888,9 +5888,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -5962,14 +5962,14 @@
 /area/eris/maintenance/section2deck5port)
 "anz" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (EAST)";
+	dir = 4;
 	icon_state = "pipe-u";
-	dir = 4
+	tag = "icon-pipe-u (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
@@ -5983,9 +5983,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
@@ -5994,9 +5994,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/random/junk/low_chance,
 /obj/random/junk/low_chance,
@@ -6008,9 +6008,9 @@
 	},
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
@@ -6019,16 +6019,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
@@ -6038,9 +6038,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /turf/simulated/floor/plating/under,
@@ -6051,9 +6051,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
@@ -6087,9 +6087,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/random/traps/low_chance,
 /turf/simulated/floor/plating/under,
@@ -6109,14 +6109,14 @@
 /area/eris/maintenance/section2deck5port)
 "anN" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
@@ -6167,9 +6167,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -6181,10 +6181,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -6215,10 +6215,10 @@
 /area/eris/maintenance/section2deck5starboard)
 "anX" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6323,10 +6323,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5port)
@@ -6386,8 +6386,8 @@
 /area/eris/maintenance/section2deck1starboard)
 "aot" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck5port)
@@ -6493,10 +6493,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -6731,9 +6731,9 @@
 /area/eris/hallway/side/eschangarb)
 "apm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/hull,
 /area/space)
@@ -6758,9 +6758,9 @@
 /area/eris/maintenance/section2deck5port)
 "aps" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/hull,
 /area/space)
@@ -6777,9 +6777,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6819,9 +6819,9 @@
 "apA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating/under,
@@ -6886,14 +6886,14 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6946,8 +6946,8 @@
 /area/eris/hallway/side/eschangarb)
 "apO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/reinforced,
 /area/eris/rnd/podbay)
@@ -6967,9 +6967,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6992,8 +6992,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/eschangarb)
@@ -7002,9 +7002,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7040,15 +7040,15 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7057,8 +7057,8 @@
 /area/eris/maintenance/section2deck5port)
 "apY" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j1"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -7071,14 +7071,14 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7213,14 +7213,14 @@
 /area/eris/maintenance/section2deck5port)
 "aqn" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (EAST)";
+	dir = 4;
 	icon_state = "pipe-u";
-	dir = 4
+	tag = "icon-pipe-u (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -7339,9 +7339,9 @@
 /area/eris/maintenance/section2deck5port)
 "aqC" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -7477,10 +7477,10 @@
 /area/eris/maintenance/section2deck5port)
 "aqO" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -7513,9 +7513,9 @@
 /area/eris/maintenance/section2deck5port)
 "aqQ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -7635,15 +7635,15 @@
 	dir = 10
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
@@ -7721,9 +7721,9 @@
 /area/eris/maintenance/section2deck5port)
 "arm" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7738,9 +7738,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
@@ -7749,14 +7749,14 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
@@ -7780,18 +7780,18 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5starboard)
 "arr" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-y (EAST)";
+	dir = 4;
 	icon_state = "pipe-y";
-	dir = 4
+	tag = "icon-pipe-y (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -8064,10 +8064,10 @@
 /area/eris/maintenance/section2deck5port)
 "arZ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8105,10 +8105,10 @@
 	dir = 5
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -8236,9 +8236,9 @@
 /area/eris/maintenance/section2deck5starboard)
 "asl" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/railing,
 /obj/structure/cable/green{
@@ -8413,10 +8413,10 @@
 /area/eris/maintenance/section2deck5port)
 "asE" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8439,9 +8439,9 @@
 /area/eris/maintenance/section2deck5starboard)
 "asG" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8485,10 +8485,10 @@
 "asK" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8509,14 +8509,14 @@
 "asM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
@@ -8542,9 +8542,9 @@
 /area/eris/maintenance/section2deck5port)
 "asP" = (
 /obj/item/modular_computer/console/preset/civilian{
-	tag = "icon-console (NORTH)";
+	dir = 1;
 	icon_state = "console";
-	dir = 1
+	tag = "icon-console (NORTH)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/eschangarb)
@@ -8635,9 +8635,9 @@
 "atc" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
@@ -8662,15 +8662,15 @@
 /area/eris/maintenance/section2deck1starboard)
 "atg" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5port)
@@ -8851,26 +8851,26 @@
 /area/eris/hallway/side/section3starboard)
 "atC" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall19";
-	icon_state = "escpodwall19"
+	icon_state = "escpodwall19";
+	tag = "icon-escpodwall19"
 	},
 /area/shuttle/escape_pod1/station)
 "atD" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall20";
-	icon_state = "escpodwall20"
+	icon_state = "escpodwall20";
+	tag = "icon-escpodwall20"
 	},
 /area/shuttle/escape_pod1/station)
 "atE" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall21";
-	icon_state = "escpodwall21"
+	icon_state = "escpodwall21";
+	tag = "icon-escpodwall21"
 	},
 /area/shuttle/escape_pod1/station)
 "atF" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall22";
-	icon_state = "escpodwall22"
+	icon_state = "escpodwall22";
+	tag = "icon-escpodwall22"
 	},
 /area/shuttle/escape_pod1/station)
 "atG" = (
@@ -8889,27 +8889,27 @@
 /area/shuttle/escape_pod1/station)
 "atI" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall25";
-	icon_state = "escpodwall25"
+	icon_state = "escpodwall25";
+	tag = "icon-escpodwall25"
 	},
 /area/shuttle/escape_pod1/station)
 "atJ" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall26";
-	icon_state = "escpodwall26"
+	icon_state = "escpodwall26";
+	tag = "icon-escpodwall26"
 	},
 /area/shuttle/escape_pod1/station)
 "atK" = (
 /obj/structure/shuttle_part/escpod{
-	tag = "icon-escpodwall27";
-	icon_state = "escpodwall27"
+	icon_state = "escpodwall27";
+	tag = "icon-escpodwall27"
 	},
 /turf/space,
 /area/shuttle/escape_pod1/station)
 "atL" = (
 /obj/structure/shuttle_part/escpod{
-	tag = "icon-escpodwall28";
-	icon_state = "escpodwall28"
+	icon_state = "escpodwall28";
+	tag = "icon-escpodwall28"
 	},
 /turf/space,
 /area/shuttle/escape_pod1/station)
@@ -8918,22 +8918,22 @@
 /area/eris/quartermaster/disposaldrop)
 "atN" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (NORTH)";
+	dir = 1;
 	icon_state = "pipe-u";
-	dir = 1
+	tag = "icon-pipe-u (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck5port)
 "atO" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -9015,8 +9015,8 @@
 /area/eris/maintenance/section3deck5port)
 "aub" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall16";
-	icon_state = "escpodwall16"
+	icon_state = "escpodwall16";
+	tag = "icon-escpodwall16"
 	},
 /area/shuttle/escape_pod1/station)
 "auc" = (
@@ -9025,8 +9025,8 @@
 	id_tag = "escape_pod_1";
 	pixel_x = -25;
 	pixel_y = 0;
-	tag_door = "escape_pod_1_hatch";
-	tag = "escape_pod_1_controller"
+	tag = "escape_pod_1_controller";
+	tag_door = "escape_pod_1_hatch"
 	},
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor{
@@ -9050,20 +9050,20 @@
 /area/shuttle/escape_pod1/station)
 "auf" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall29";
-	icon_state = "escpodwall29"
+	icon_state = "escpodwall29";
+	tag = "icon-escpodwall29"
 	},
 /area/shuttle/escape_pod1/station)
 "aug" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall17";
-	icon_state = "escpodwall17"
+	icon_state = "escpodwall17";
+	tag = "icon-escpodwall17"
 	},
 /area/shuttle/escape_pod1/station)
 "auh" = (
 /obj/structure/shuttle_part/escpod{
-	tag = "icon-escpodwall18";
-	icon_state = "escpodwall18"
+	icon_state = "escpodwall18";
+	tag = "icon-escpodwall18"
 	},
 /turf/space,
 /area/shuttle/escape_pod1/station)
@@ -9112,9 +9112,9 @@
 /area/eris/quartermaster/disposaldrop)
 "aup" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -9146,14 +9146,14 @@
 	},
 /obj/effect/shuttle_landmark/escape_pod/start/pod1,
 /turf/simulated/shuttle/floor{
-	tag = "icon-cargofloor7";
-	icon_state = "cargofloor7"
+	icon_state = "cargofloor7";
+	tag = "icon-cargofloor7"
 	},
 /area/shuttle/escape_pod1/station)
 "aut" = (
 /turf/simulated/shuttle/floor{
-	tag = "icon-cargofloor7";
-	icon_state = "cargofloor7"
+	icon_state = "cargofloor7";
+	tag = "icon-cargofloor7"
 	},
 /area/shuttle/escape_pod1/station)
 "auu" = (
@@ -9173,14 +9173,14 @@
 /area/shuttle/escape_pod1/station)
 "auv" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall14";
-	icon_state = "escpodwall14"
+	icon_state = "escpodwall14";
+	tag = "icon-escpodwall14"
 	},
 /area/shuttle/escape_pod1/station)
 "auw" = (
 /obj/structure/shuttle_part/escpod{
-	tag = "icon-escpodwall15";
-	icon_state = "escpodwall15"
+	icon_state = "escpodwall15";
+	tag = "icon-escpodwall15"
 	},
 /turf/space,
 /area/shuttle/escape_pod1/station)
@@ -9213,8 +9213,8 @@
 /area/eris/crew_quarters/bar)
 "auA" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall11";
-	icon_state = "escpodwall11"
+	icon_state = "escpodwall11";
+	tag = "icon-escpodwall11"
 	},
 /area/shuttle/escape_pod1/station)
 "auB" = (
@@ -9223,9 +9223,9 @@
 	pixel_x = -22
 	},
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair (NORTH)";
+	dir = 1;
 	icon_state = "shuttle_chair";
-	dir = 1
+	tag = "icon-shuttle_chair (NORTH)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "cargofloor1"
@@ -9233,9 +9233,9 @@
 /area/shuttle/escape_pod1/station)
 "auC" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair (NORTH)";
+	dir = 1;
 	icon_state = "shuttle_chair";
-	dir = 1
+	tag = "icon-shuttle_chair (NORTH)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "cargofloor1"
@@ -9243,9 +9243,9 @@
 /area/shuttle/escape_pod1/station)
 "auD" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair (NORTH)";
+	dir = 1;
 	icon_state = "shuttle_chair";
-	dir = 1
+	tag = "icon-shuttle_chair (NORTH)"
 	},
 /obj/machinery/light,
 /turf/simulated/shuttle/floor{
@@ -9254,14 +9254,14 @@
 /area/shuttle/escape_pod1/station)
 "auE" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall12";
-	icon_state = "escpodwall12"
+	icon_state = "escpodwall12";
+	tag = "icon-escpodwall12"
 	},
 /area/shuttle/escape_pod1/station)
 "auF" = (
 /obj/structure/shuttle_part/escpod{
-	tag = "icon-escpodwall13";
-	icon_state = "escpodwall13"
+	icon_state = "escpodwall13";
+	tag = "icon-escpodwall13"
 	},
 /turf/space,
 /area/shuttle/escape_pod1/station)
@@ -9278,20 +9278,20 @@
 /area/shuttle/escape_pod1/station)
 "auJ" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall2";
-	icon_state = "escpodwall2"
+	icon_state = "escpodwall2";
+	tag = "icon-escpodwall2"
 	},
 /area/shuttle/escape_pod1/station)
 "auK" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall3";
-	icon_state = "escpodwall3"
+	icon_state = "escpodwall3";
+	tag = "icon-escpodwall3"
 	},
 /area/shuttle/escape_pod1/station)
 "auL" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall4";
-	icon_state = "escpodwall4"
+	icon_state = "escpodwall4";
+	tag = "icon-escpodwall4"
 	},
 /area/shuttle/escape_pod1/station)
 "auM" = (
@@ -9310,27 +9310,27 @@
 /area/shuttle/escape_pod1/station)
 "auO" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall7";
-	icon_state = "escpodwall7"
+	icon_state = "escpodwall7";
+	tag = "icon-escpodwall7"
 	},
 /area/shuttle/escape_pod1/station)
 "auP" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall8";
-	icon_state = "escpodwall8"
+	icon_state = "escpodwall8";
+	tag = "icon-escpodwall8"
 	},
 /area/shuttle/escape_pod1/station)
 "auQ" = (
 /obj/structure/shuttle_part/escpod{
-	tag = "icon-escpodwall9";
-	icon_state = "escpodwall9"
+	icon_state = "escpodwall9";
+	tag = "icon-escpodwall9"
 	},
 /turf/space,
 /area/shuttle/escape_pod1/station)
 "auR" = (
 /obj/structure/shuttle_part/escpod{
-	tag = "icon-escpodwall10";
-	icon_state = "escpodwall10"
+	icon_state = "escpodwall10";
+	tag = "icon-escpodwall10"
 	},
 /turf/space,
 /area/shuttle/escape_pod1/station)
@@ -9388,18 +9388,18 @@
 /area/eris/quartermaster/disposaldrop)
 "ava" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/lattice,
 /turf/space,
 /area/space)
 "avb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/lattice,
 /turf/space,
@@ -9437,18 +9437,18 @@
 /area/eris/hallway/side/eschangara)
 "avh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/hull,
 /area/space)
 "avi" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/space,
 /area/space)
@@ -9509,9 +9509,9 @@
 /area/eris/maintenance/section3deck5port)
 "avq" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
@@ -9542,9 +9542,9 @@
 /area/eris/maintenance/section3deck5port)
 "avw" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating/under,
@@ -9639,10 +9639,10 @@
 /area/eris/neotheology/chapelritualroom)
 "avL" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
@@ -9994,9 +9994,9 @@
 /area/eris/neotheology/storage)
 "awK" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
@@ -10122,14 +10122,14 @@
 /area/eris/maintenance/section3deck2starboard)
 "axa" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
@@ -10254,9 +10254,9 @@
 /area/eris/maintenance/section2deck5starboard)
 "axo" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck2starboard)
@@ -10275,9 +10275,9 @@
 /area/eris/maintenance/section3deck2starboard)
 "axr" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (WEST)";
+	dir = 8;
 	icon_state = "pipe-d";
-	dir = 8
+	tag = "icon-pipe-d (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
@@ -10902,8 +10902,8 @@
 /area/eris/maintenance/section3deck5port)
 "ayO" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j1"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -10918,8 +10918,8 @@
 /area/eris/maintenance/section3deck5port)
 "ayP" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10983,9 +10983,9 @@
 /area/eris/maintenance/junk)
 "ayY" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -11028,9 +11028,9 @@
 /area/eris/crew_quarters/library)
 "azd" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
@@ -11077,15 +11077,15 @@
 	},
 /obj/machinery/light/small,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
@@ -11099,9 +11099,9 @@
 	dir = 5
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
@@ -11129,9 +11129,9 @@
 /area/eris/neotheology/bioreactor)
 "azp" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/closet/crate/internals,
 /obj/item/device/radio/intercom{
@@ -11308,10 +11308,9 @@
 /obj/machinery/button/remote/blast_door{
 	id = "Armoury";
 	name = "Armoury Access";
-	pixel_x = 7;
+	pixel_x = 0;
 	pixel_y = 25;
-	req_access = list(3);
-	pixel_x = 0
+	req_access = list(3)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/warden)
@@ -11523,9 +11522,9 @@
 /area/eris/maintenance/disposal)
 "aAj" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/machinery/button/ignition{
 	id = "Incinerator";
@@ -11653,10 +11652,10 @@
 /area/eris/hallway/side/eschangara)
 "aAx" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
@@ -11677,17 +11676,17 @@
 /area/eris/quartermaster/disposaldrop)
 "aAA" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
 "aAB" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/machinery/meter,
 /obj/structure/cable/green{
@@ -11711,9 +11710,9 @@
 /area/eris/maintenance/disposal)
 "aAD" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -11760,8 +11759,8 @@
 /area/eris/security/warden)
 "aAH" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-y";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-y"
 	},
 /obj/machinery/conveyor_switch{
 	id = "disposal3"
@@ -11770,10 +11769,10 @@
 /area/eris/maintenance/disposal)
 "aAI" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
@@ -12142,8 +12141,8 @@
 /area/eris/maintenance/section3deck2starboard)
 "aBE" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/dispenser,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -12187,10 +12186,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5starboard)
@@ -12348,9 +12347,9 @@
 /area/eris/maintenance/section4deck5port)
 "aCf" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "maint_hatch_maintcryostor";
@@ -12502,14 +12501,14 @@
 /area/eris/security/prisoncells)
 "aCy" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
@@ -12575,22 +12574,22 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
 "aCI" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -12889,26 +12888,26 @@
 /area/eris/security/main)
 "aDy" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall19";
-	icon_state = "escpodwall19"
+	icon_state = "escpodwall19";
+	tag = "icon-escpodwall19"
 	},
 /area/shuttle/escape_pod2/station)
 "aDz" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall20";
-	icon_state = "escpodwall20"
+	icon_state = "escpodwall20";
+	tag = "icon-escpodwall20"
 	},
 /area/shuttle/escape_pod2/station)
 "aDA" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall21";
-	icon_state = "escpodwall21"
+	icon_state = "escpodwall21";
+	tag = "icon-escpodwall21"
 	},
 /area/shuttle/escape_pod2/station)
 "aDB" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall22";
-	icon_state = "escpodwall22"
+	icon_state = "escpodwall22";
+	tag = "icon-escpodwall22"
 	},
 /area/shuttle/escape_pod2/station)
 "aDC" = (
@@ -12927,27 +12926,27 @@
 /area/shuttle/escape_pod2/station)
 "aDE" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall25";
-	icon_state = "escpodwall25"
+	icon_state = "escpodwall25";
+	tag = "icon-escpodwall25"
 	},
 /area/shuttle/escape_pod2/station)
 "aDF" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall26";
-	icon_state = "escpodwall26"
+	icon_state = "escpodwall26";
+	tag = "icon-escpodwall26"
 	},
 /area/shuttle/escape_pod2/station)
 "aDG" = (
 /obj/structure/shuttle_part/escpod{
-	tag = "icon-escpodwall27";
-	icon_state = "escpodwall27"
+	icon_state = "escpodwall27";
+	tag = "icon-escpodwall27"
 	},
 /turf/space,
 /area/shuttle/escape_pod2/station)
 "aDH" = (
 /obj/structure/shuttle_part/escpod{
-	tag = "icon-escpodwall28";
-	icon_state = "escpodwall28"
+	icon_state = "escpodwall28";
+	tag = "icon-escpodwall28"
 	},
 /turf/space,
 /area/shuttle/escape_pod2/station)
@@ -13159,8 +13158,8 @@
 /area/eris/crew_quarters/sleep)
 "aEg" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall16";
-	icon_state = "escpodwall16"
+	icon_state = "escpodwall16";
+	tag = "icon-escpodwall16"
 	},
 /area/shuttle/escape_pod2/station)
 "aEh" = (
@@ -13170,8 +13169,8 @@
 	id_tag = "escape_pod_2";
 	pixel_x = -25;
 	pixel_y = 0;
-	tag_door = "escape_pod_2_hatch";
-	tag = "escape_pod_2_controller"
+	tag = "escape_pod_2_controller";
+	tag_door = "escape_pod_2_hatch"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "cargofloor1"
@@ -13194,20 +13193,20 @@
 /area/shuttle/escape_pod2/station)
 "aEk" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall29";
-	icon_state = "escpodwall29"
+	icon_state = "escpodwall29";
+	tag = "icon-escpodwall29"
 	},
 /area/shuttle/escape_pod2/station)
 "aEl" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall17";
-	icon_state = "escpodwall17"
+	icon_state = "escpodwall17";
+	tag = "icon-escpodwall17"
 	},
 /area/shuttle/escape_pod2/station)
 "aEm" = (
 /obj/structure/shuttle_part/escpod{
-	tag = "icon-escpodwall18";
-	icon_state = "escpodwall18"
+	icon_state = "escpodwall18";
+	tag = "icon-escpodwall18"
 	},
 /turf/space,
 /area/shuttle/escape_pod2/station)
@@ -13449,9 +13448,9 @@
 /area/eris/security/prisoncells)
 "aEQ" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -13472,14 +13471,14 @@
 	},
 /obj/effect/shuttle_landmark/escape_pod/start/pod2,
 /turf/simulated/shuttle/floor{
-	tag = "icon-cargofloor7";
-	icon_state = "cargofloor7"
+	icon_state = "cargofloor7";
+	tag = "icon-cargofloor7"
 	},
 /area/shuttle/escape_pod2/station)
 "aES" = (
 /turf/simulated/shuttle/floor{
-	tag = "icon-cargofloor7";
-	icon_state = "cargofloor7"
+	icon_state = "cargofloor7";
+	tag = "icon-cargofloor7"
 	},
 /area/shuttle/escape_pod2/station)
 "aET" = (
@@ -13499,14 +13498,14 @@
 /area/shuttle/escape_pod2/station)
 "aEU" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall14";
-	icon_state = "escpodwall14"
+	icon_state = "escpodwall14";
+	tag = "icon-escpodwall14"
 	},
 /area/shuttle/escape_pod2/station)
 "aEV" = (
 /obj/structure/shuttle_part/escpod{
-	tag = "icon-escpodwall15";
-	icon_state = "escpodwall15"
+	icon_state = "escpodwall15";
+	tag = "icon-escpodwall15"
 	},
 /turf/space,
 /area/shuttle/escape_pod2/station)
@@ -13570,18 +13569,18 @@
 /area/eris/engineering/atmos)
 "aFh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
 "aFi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/item/device/radio/intercom{
 	dir = 2;
@@ -13591,9 +13590,9 @@
 /area/eris/engineering/atmos)
 "aFj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
@@ -13634,9 +13633,9 @@
 /area/eris/engineering/atmos)
 "aFq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -13675,17 +13674,17 @@
 /area/eris/maintenance/junk)
 "aFw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/atmos)
 "aFx" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall11";
-	icon_state = "escpodwall11"
+	icon_state = "escpodwall11";
+	tag = "icon-escpodwall11"
 	},
 /area/shuttle/escape_pod2/station)
 "aFy" = (
@@ -13694,9 +13693,9 @@
 	pixel_x = -22
 	},
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair (NORTH)";
+	dir = 1;
 	icon_state = "shuttle_chair";
-	dir = 1
+	tag = "icon-shuttle_chair (NORTH)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "cargofloor1"
@@ -13704,9 +13703,9 @@
 /area/shuttle/escape_pod2/station)
 "aFz" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair (NORTH)";
+	dir = 1;
 	icon_state = "shuttle_chair";
-	dir = 1
+	tag = "icon-shuttle_chair (NORTH)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "cargofloor1"
@@ -13714,9 +13713,9 @@
 /area/shuttle/escape_pod2/station)
 "aFA" = (
 /obj/structure/bed/chair/shuttle{
-	tag = "icon-shuttle_chair (NORTH)";
+	dir = 1;
 	icon_state = "shuttle_chair";
-	dir = 1
+	tag = "icon-shuttle_chair (NORTH)"
 	},
 /obj/machinery/light,
 /turf/simulated/shuttle/floor{
@@ -13725,14 +13724,14 @@
 /area/shuttle/escape_pod2/station)
 "aFB" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall12";
-	icon_state = "escpodwall12"
+	icon_state = "escpodwall12";
+	tag = "icon-escpodwall12"
 	},
 /area/shuttle/escape_pod2/station)
 "aFC" = (
 /obj/structure/shuttle_part/escpod{
-	tag = "icon-escpodwall13";
-	icon_state = "escpodwall13"
+	icon_state = "escpodwall13";
+	tag = "icon-escpodwall13"
 	},
 /turf/space,
 /area/shuttle/escape_pod2/station)
@@ -13769,9 +13768,9 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/space,
 /area/space)
@@ -13781,9 +13780,9 @@
 /area/eris/maintenance/section1deck4central)
 "aFJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plating/under,
@@ -13900,20 +13899,20 @@
 /area/shuttle/escape_pod2/station)
 "aGd" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall2";
-	icon_state = "escpodwall2"
+	icon_state = "escpodwall2";
+	tag = "icon-escpodwall2"
 	},
 /area/shuttle/escape_pod2/station)
 "aGe" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall3";
-	icon_state = "escpodwall3"
+	icon_state = "escpodwall3";
+	tag = "icon-escpodwall3"
 	},
 /area/shuttle/escape_pod2/station)
 "aGf" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall4";
-	icon_state = "escpodwall4"
+	icon_state = "escpodwall4";
+	tag = "icon-escpodwall4"
 	},
 /area/shuttle/escape_pod2/station)
 "aGg" = (
@@ -13932,27 +13931,27 @@
 /area/shuttle/escape_pod2/station)
 "aGi" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall7";
-	icon_state = "escpodwall7"
+	icon_state = "escpodwall7";
+	tag = "icon-escpodwall7"
 	},
 /area/shuttle/escape_pod2/station)
 "aGj" = (
 /turf/simulated/shuttle/wall/escpod{
-	tag = "icon-escpodwall8";
-	icon_state = "escpodwall8"
+	icon_state = "escpodwall8";
+	tag = "icon-escpodwall8"
 	},
 /area/shuttle/escape_pod2/station)
 "aGk" = (
 /obj/structure/shuttle_part/escpod{
-	tag = "icon-escpodwall9";
-	icon_state = "escpodwall9"
+	icon_state = "escpodwall9";
+	tag = "icon-escpodwall9"
 	},
 /turf/space,
 /area/shuttle/escape_pod2/station)
 "aGl" = (
 /obj/structure/shuttle_part/escpod{
-	tag = "icon-escpodwall10";
-	icon_state = "escpodwall10"
+	icon_state = "escpodwall10";
+	tag = "icon-escpodwall10"
 	},
 /turf/space,
 /area/shuttle/escape_pod2/station)
@@ -13995,9 +13994,9 @@
 /area/eris/engineering/atmos)
 "aGt" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/machinery/power/apc{
 	cell_type = /obj/item/weapon/cell/large/high;
@@ -14152,8 +14151,8 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
@@ -14199,16 +14198,16 @@
 /area/space)
 "aGS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/atmos)
 "aGT" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
@@ -14227,9 +14226,9 @@
 /area/eris/engineering/atmos)
 "aGW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -14246,9 +14245,9 @@
 /area/eris/engineering/atmos)
 "aGY" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
@@ -14300,9 +14299,9 @@
 /area/eris/engineering/atmos)
 "aHf" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	tag = "icon-map (WEST)";
+	dir = 8;
 	icon_state = "map";
-	dir = 8
+	tag = "icon-map (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -14369,9 +14368,9 @@
 /area/eris/engineering/atmos)
 "aHq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
@@ -14405,9 +14404,9 @@
 /area/eris/engineering/atmos)
 "aHv" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/atmos)
@@ -14421,16 +14420,16 @@
 "aHx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
 "aHy" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
@@ -14484,9 +14483,9 @@
 /area/eris/engineering/atmos)
 "aHG" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -14698,9 +14697,9 @@
 /area/eris/engineering/atmos)
 "aIk" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
@@ -14801,9 +14800,9 @@
 /area/eris/rnd/chargebay)
 "aIy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
@@ -14876,9 +14875,9 @@
 /area/eris/engineering/atmos)
 "aII" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
-	tag = "icon-map (WEST)";
+	dir = 8;
 	icon_state = "map";
-	dir = 8
+	tag = "icon-map (WEST)"
 	},
 /obj/machinery/meter{
 	frequency = 1443;
@@ -14897,9 +14896,9 @@
 /area/eris/engineering/atmos)
 "aIK" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/machinery/meter{
 	frequency = 1443;
@@ -14926,9 +14925,9 @@
 /area/turret_protected/ai)
 "aIO" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
@@ -15037,9 +15036,9 @@
 /area/eris/maintenance/section4deck5port)
 "aJc" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -15081,9 +15080,9 @@
 /area/eris/engineering/atmos)
 "aJg" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating/under,
@@ -15120,30 +15119,30 @@
 /area/eris/engineering/atmos)
 "aJm" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	tag = "icon-map (WEST)";
+	dir = 8;
 	icon_state = "map";
-	dir = 8
+	tag = "icon-map (WEST)"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
 "aJn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
 "aJo" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 2;
@@ -15153,9 +15152,9 @@
 /area/eris/engineering/atmos)
 "aJp" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
@@ -15170,9 +15169,9 @@
 /area/eris/engineering/atmos)
 "aJs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -15246,9 +15245,9 @@
 /area/eris/security/prisoncells)
 "aJA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -15421,9 +15420,9 @@
 /area/eris/engineering/atmos)
 "aJW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
@@ -15457,9 +15456,9 @@
 /area/eris/engineering/atmos)
 "aKb" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -15497,14 +15496,14 @@
 /area/eris/engineering/atmos)
 "aKh" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (EAST)";
+	dir = 4;
 	icon_state = "pipe-u";
-	dir = 4
+	tag = "icon-pipe-u (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
@@ -15574,9 +15573,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/space,
 /area/space)
@@ -15606,9 +15605,9 @@
 "aKw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/atmos)
@@ -15629,9 +15628,9 @@
 "aKy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/atmos)
@@ -15653,9 +15652,9 @@
 /area/eris/engineering/atmos)
 "aKB" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
@@ -15720,9 +15719,9 @@
 /area/eris/maintenance/section4deck5port)
 "aKM" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
@@ -15777,22 +15776,22 @@
 /area/eris/maintenance/section1deck4central)
 "aKT" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "aKU" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -15822,25 +15821,25 @@
 /area/eris/engineering/atmos)
 "aKZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/atmos)
 "aLa" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/atmos)
 "aLb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating/under,
@@ -15881,9 +15880,9 @@
 /area/eris/maintenance/section3deck5starboard)
 "aLg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/atmos)
@@ -15927,17 +15926,17 @@
 /area/eris/engineering/atmos)
 "aLn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/atmos)
 "aLo" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/atmos)
@@ -16011,9 +16010,9 @@
 /area/eris/maintenance/section3deck5starboard)
 "aLA" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
@@ -16102,17 +16101,17 @@
 /area/eris/engineering/atmos)
 "aLK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/atmos)
 "aLL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/atmos)
@@ -16139,17 +16138,17 @@
 /area/eris/security/warden)
 "aLP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/atmos)
 "aLQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/atmos)
@@ -16183,10 +16182,10 @@
 /area/eris/maintenance/section4deck5port)
 "aLU" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck1central)
@@ -16253,9 +16252,9 @@
 /area/eris/rnd/podbay)
 "aMe" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck1central)
@@ -16284,9 +16283,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
@@ -16373,9 +16372,9 @@
 /area/eris/engineering/atmos)
 "aMs" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/atmos)
@@ -16395,9 +16394,9 @@
 /area/eris/maintenance/section3deck1central)
 "aMw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/atmos)
@@ -16418,9 +16417,9 @@
 /area/eris/hallway/side/eschangarb)
 "aMz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -16555,8 +16554,8 @@
 /area/eris/rnd/server)
 "aMS" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/bluegrid{
 	name = "Server Base";
@@ -16571,9 +16570,9 @@
 /area/eris/maintenance/section1deck4central)
 "aMU" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/bluegrid{
 	name = "Server Base";
@@ -16584,9 +16583,9 @@
 /area/eris/rnd/server)
 "aMV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
@@ -16619,10 +16618,10 @@
 /area/eris/maintenance/section4deck5port)
 "aNa" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
@@ -16637,9 +16636,9 @@
 /area/eris/maintenance/section1deck4central)
 "aNd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -16689,9 +16688,9 @@
 /area/eris/rnd/server)
 "aNk" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/bluegrid{
 	name = "Server Base";
@@ -16719,9 +16718,9 @@
 /area/eris/hallway/side/atmosphericshallway)
 "aNn" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -16761,9 +16760,9 @@
 /area/eris/maintenance/section4deck5port)
 "aNs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/bluegrid{
 	name = "Server Base";
@@ -16796,9 +16795,9 @@
 "aNu" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
@@ -16818,15 +16817,15 @@
 /area/eris/maintenance/section1deck4central)
 "aNx" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
@@ -16848,9 +16847,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
@@ -16886,23 +16885,23 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
 "aNG" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -16922,17 +16921,17 @@
 /area/eris/maintenance/section3deck1central)
 "aNI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "aNJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -16994,16 +16993,16 @@
 /area/eris/maintenance/section4deck5port)
 "aNR" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
 "aNS" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -17278,8 +17277,8 @@
 /area/eris/engineering/atmos)
 "aOB" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/hull,
 /area/eris/maintenance/junk)
@@ -17495,8 +17494,8 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/aiModule/corp,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -17505,9 +17504,9 @@
 	dir = 8
 	},
 /obj/machinery/flasher{
+	id = "AI";
 	pixel_x = 0;
-	pixel_y = 24;
-	id = "AI"
+	pixel_y = 24
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -17680,9 +17679,9 @@
 /area/eris/maintenance/section1deck4central)
 "aPD" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -17797,9 +17796,9 @@
 /area/eris/security/prisoncells)
 "aPO" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -17813,9 +17812,9 @@
 /area/eris/maintenance/section4deck5port)
 "aPP" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -17830,14 +17829,14 @@
 /area/eris/maintenance/section4deck5port)
 "aPQ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -17891,14 +17890,14 @@
 "aPT" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -17930,9 +17929,9 @@
 /area/eris/security/prisoncells)
 "aPV" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /obj/structure/cable/green{
@@ -18030,9 +18029,9 @@
 /area/eris/maintenance/section4deck5port)
 "aQb" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18065,9 +18064,9 @@
 /area/eris/maintenance/section4deck5port)
 "aQd" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
@@ -18089,9 +18088,9 @@
 "aQg" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -18133,18 +18132,18 @@
 "aQl" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
 "aQm" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
@@ -18168,10 +18167,10 @@
 /area/eris/maintenance/section4deck5port)
 "aQq" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating/under,
@@ -18183,10 +18182,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating/under,
@@ -18255,9 +18254,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
@@ -18615,9 +18614,9 @@
 /area/eris/security/barracks)
 "aRr" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -18656,9 +18655,9 @@
 /area/eris/security/main)
 "aRx" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -18866,9 +18865,9 @@
 /area/eris/engineering/atmos/storage)
 "aRU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/phoron,
@@ -18932,9 +18931,9 @@
 /area/eris/security/barracks)
 "aSc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
@@ -19045,9 +19044,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
@@ -19117,17 +19116,14 @@
 "aSv" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/welding{
-	pixel_x = 1;
 	pixel_x = -5;
 	pixel_y = 3
 	},
 /obj/item/clothing/head/welding{
-	pixel_x = 1;
 	pixel_x = -5;
 	pixel_y = 3
 	},
 /obj/item/clothing/head/welding{
-	pixel_x = 1;
 	pixel_x = -5;
 	pixel_y = 3
 	},
@@ -19443,9 +19439,9 @@
 /area/eris/maintenance/section1deck4central)
 "aTi" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -19509,9 +19505,9 @@
 /area/eris/security/armory)
 "aTq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -19668,9 +19664,9 @@
 /area/eris/maintenance/section1deck4central)
 "aTJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
@@ -20218,9 +20214,9 @@
 /area/eris/maintenance/section1deck4central)
 "aUU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/meter,
 /obj/machinery/door/firedoor,
@@ -20618,27 +20614,27 @@
 "aVM" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/security/prison)
 "aVN" = (
 /obj/structure/catwalk,
 /obj/machinery/nuclearbomb{
-	r_code = "LOLNO";
-	eris_ship_bomb = 1
+	eris_ship_bomb = 1;
+	r_code = "LOLNO"
 	},
 /turf/simulated/open,
 /area/eris/security/prison)
 "aVO" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/security/prison)
@@ -20675,9 +20671,9 @@
 /area/eris/maintenance/section1deck4central)
 "aVT" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -20993,9 +20989,9 @@
 /area/eris/maintenance/section3deck4port)
 "aWz" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -21022,15 +21018,15 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
@@ -21280,27 +21276,27 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/random/flora/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "aXk" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/eris/security/prison)
 "aXl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -21548,9 +21544,9 @@
 /area/eris/maintenance/section4deck5port)
 "aXN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -21688,9 +21684,9 @@
 /area/eris/maintenance/section2deck4port)
 "aYc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -21890,16 +21886,16 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -21916,10 +21912,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -21927,9 +21923,9 @@
 "aYA" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
@@ -21944,10 +21940,10 @@
 "aYC" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
@@ -22043,8 +22039,8 @@
 /area/eris/security/evidencestorage)
 "aYO" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -22137,9 +22133,9 @@
 /area/eris/maintenance/section1deck4central)
 "aYV" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/open,
@@ -22150,10 +22146,10 @@
 /area/eris/crew_quarters/sleep)
 "aYX" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/open,
@@ -22271,10 +22267,10 @@
 /area/eris/hallway/side/eschangara)
 "aZm" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/open,
@@ -22308,8 +22304,8 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/lab)
@@ -22367,9 +22363,9 @@
 "aZw" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck1central)
@@ -22463,10 +22459,10 @@
 	dir = 10
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -22546,49 +22542,49 @@
 /area/eris/maintenance/section3deck1central)
 "aZO" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "aZP" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "aZQ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "aZR" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
@@ -22597,22 +22593,22 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "aZT" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (WEST)";
+	dir = 8;
 	icon_state = "pipe-d";
-	dir = 8
+	tag = "icon-pipe-d (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -22681,10 +22677,10 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -22857,18 +22853,18 @@
 /area/eris/security/main)
 "bal" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "bam" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
@@ -22899,10 +22895,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -22924,17 +22920,17 @@
 /area/eris/maintenance/section1deck4central)
 "bar" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "bas" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section1deck4central)
@@ -22953,9 +22949,9 @@
 /area/eris/maintenance/section1deck4central)
 "bau" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23148,8 +23144,8 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/aiModule/robocop,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/sign/department/ai{
 	pixel_x = 32
@@ -23268,14 +23264,14 @@
 /area/eris/maintenance/section1deck4central)
 "bbh" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -23290,9 +23286,9 @@
 /area/eris/maintenance/section1deck4central)
 "bbi" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -23311,16 +23307,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -23332,10 +23328,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -23349,10 +23345,10 @@
 	pixel_y = 0
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -23365,16 +23361,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -23421,10 +23417,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -23473,9 +23469,9 @@
 /area/eris/medical/virology)
 "bbA" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -23630,10 +23626,10 @@
 	icon_state = "2-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -23732,10 +23728,10 @@
 	dir = 5
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -23763,16 +23759,16 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -23787,10 +23783,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -23841,10 +23837,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -23858,9 +23854,9 @@
 /area/eris/engineering/atmos/storage)
 "bce" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -24019,16 +24015,16 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -24084,10 +24080,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -24231,10 +24227,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -24285,10 +24281,10 @@
 	pixel_x = 0
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -24305,10 +24301,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -24350,10 +24346,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -24393,18 +24389,18 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "bcQ" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j2";
-	dir = 1
+	tag = "icon-pipe-j2 (NORTH)"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -24429,10 +24425,10 @@
 /area/eris/maintenance/section1deck4central)
 "bcS" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -24530,9 +24526,9 @@
 /area/eris/maintenance/section3deck4port)
 "bda" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -24585,10 +24581,10 @@
 "bdg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/open,
@@ -24596,9 +24592,9 @@
 "bdh" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -24638,10 +24634,10 @@
 	icon_state = "1-4"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -24655,10 +24651,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -24672,10 +24668,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -24692,10 +24688,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -24703,16 +24699,16 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -24797,10 +24793,10 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -24820,14 +24816,14 @@
 /area/eris/maintenance/section3deck1central)
 "bdA" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (NORTH)";
+	dir = 1;
 	icon_state = "pipe-u";
-	dir = 1
+	tag = "icon-pipe-u (NORTH)"
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -24839,14 +24835,14 @@
 /area/eris/maintenance/section1deck4central)
 "bdB" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (NORTH)";
+	dir = 1;
 	icon_state = "pipe-u";
-	dir = 1
+	tag = "icon-pipe-u (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
@@ -24864,27 +24860,27 @@
 "bdD" = (
 /obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/section1)
 "bdE" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "bdF" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/open,
@@ -24958,14 +24954,14 @@
 /area/eris/maintenance/section2deck4central)
 "bdS" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (WEST)";
+	dir = 8;
 	icon_state = "pipe-d";
-	dir = 8
+	tag = "icon-pipe-d (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section2deck4central)
@@ -24975,29 +24971,29 @@
 /area/eris/maintenance/section2deck2starboard)
 "bdU" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
 "bdV" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -25008,44 +25004,44 @@
 /area/eris/maintenance/section2deck2port)
 "bdX" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
 "bdY" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/random/flora/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
 "bdZ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -25053,9 +25049,9 @@
 "bea" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -25068,10 +25064,10 @@
 /area/eris/crew_quarters/sleep/cryo)
 "bec" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
@@ -25083,10 +25079,10 @@
 "bee" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/contraband/low_chance,
 /turf/simulated/floor/plating/under,
@@ -25110,10 +25106,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
@@ -25167,9 +25163,9 @@
 /area/eris/medical/medbreak)
 "bep" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/lattice,
@@ -25177,10 +25173,10 @@
 /area/eris/crew_quarters/sleep)
 "beq" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/lattice,
@@ -25189,10 +25185,10 @@
 "ber" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/lattice,
@@ -25217,10 +25213,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
@@ -25239,9 +25235,9 @@
 /area/eris/maintenance/section2deck4port)
 "bex" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 16;
@@ -25333,14 +25329,14 @@
 /area/eris/rnd/robotics)
 "beG" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -25353,35 +25349,35 @@
 /area/eris/crew_quarters/sleep)
 "beI" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "beJ" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (NORTH)";
+	dir = 1;
 	icon_state = "pipe-d";
-	dir = 1
+	tag = "icon-pipe-d (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -25399,10 +25395,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -25797,9 +25793,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -25982,10 +25978,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -26093,10 +26089,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -26128,10 +26124,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -26330,10 +26326,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -26426,9 +26422,9 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -26488,10 +26484,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
@@ -26530,16 +26526,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
@@ -26675,10 +26671,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -26843,9 +26839,9 @@
 /area/eris/security/barracks)
 "bij" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -26875,8 +26871,8 @@
 /area/eris/maintenance/section2deck4starboard)
 "bin" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -26886,17 +26882,17 @@
 /area/eris/maintenance/section2deck4starboard)
 "bio" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/maintenance/section3deck1central)
 "bip" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/maintenance/section3deck1central)
@@ -26962,10 +26958,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -27207,8 +27203,8 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/sign/department/robo{
 	pixel_x = 32
@@ -27262,15 +27258,15 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -27282,10 +27278,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -27297,16 +27293,16 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -27322,9 +27318,9 @@
 /area/eris/maintenance/section2deck4port)
 "bji" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck1central)
@@ -27342,9 +27338,9 @@
 /area/eris/security/prison)
 "bjl" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j2";
-	dir = 1
+	tag = "icon-pipe-j2 (NORTH)"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -27362,8 +27358,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -27471,8 +27467,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcorner"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -27604,10 +27600,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -27616,9 +27612,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -27799,8 +27795,8 @@
 /area/eris/rnd/robotics)
 "bkd" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -27843,9 +27839,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -27992,10 +27988,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -28097,14 +28093,14 @@
 /area/eris/maintenance/section3deck5port)
 "bkD" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (NORTH)";
+	dir = 1;
 	icon_state = "pipe-d";
-	dir = 1
+	tag = "icon-pipe-d (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section2deck4starboard)
@@ -28349,9 +28345,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/landmark/storyevent/midgame_stash_spawn{
 	navigation = "Section 2, floor 2. Maints east from RnD, behind the glass."
@@ -28481,14 +28477,14 @@
 /area/eris/maintenance/section3deck1central)
 "blu" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (WEST)";
+	dir = 8;
 	icon_state = "pipe-d";
-	dir = 8
+	tag = "icon-pipe-d (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck1central)
@@ -28599,8 +28595,8 @@
 /area/eris/maintenance/section3deck1central)
 "blI" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Telecommunications"
@@ -28706,10 +28702,10 @@
 /area/eris/maintenance/section3deck1central)
 "blY" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck1central)
@@ -28743,8 +28739,8 @@
 "bmd" = (
 /obj/machinery/vending/assist,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/lab)
@@ -28906,8 +28902,8 @@
 /area/eris/security/evidencestorage)
 "bmu" = (
 /obj/machinery/shower{
-	icon_state = "shower";
-	dir = 4
+	dir = 4;
+	icon_state = "shower"
 	},
 /obj/machinery/camera/network/medbay{
 	dir = 1
@@ -29171,9 +29167,9 @@
 /area/eris/maintenance/section2deck4port)
 "bmX" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down{
 	dir = 4
@@ -29366,15 +29362,15 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -29391,9 +29387,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -29427,8 +29423,8 @@
 /area/eris/maintenance/section3deck4central)
 "bnv" = (
 /obj/machinery/shower{
-	icon_state = "shower";
-	dir = 8
+	dir = 8;
+	icon_state = "shower"
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -29663,8 +29659,8 @@
 /area/eris/maintenance/section3deck1central)
 "bnU" = (
 /obj/structure/morgue{
-	icon_state = "morgue1";
-	dir = 8
+	dir = 8;
+	icon_state = "morgue1"
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/medical/morgue)
@@ -29835,10 +29831,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/metal/mait{
-	tag = "icon-door_closed";
-	name = "Central Maintenance";
+	dir = 2;
 	icon_state = "door_closed";
-	dir = 2
+	name = "Central Maintenance";
+	tag = "icon-door_closed"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -29866,8 +29862,8 @@
 /area/eris/maintenance/section3deck1central)
 "bow" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -29940,8 +29936,6 @@
 "boD" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/gloves{
-	pixel_x = -4;
-	pixel_y = -3;
 	pixel_x = 3;
 	pixel_y = 4
 	},
@@ -29988,8 +29982,8 @@
 /area/eris/maintenance/section3deck1central)
 "boJ" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -30037,10 +30031,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -30148,8 +30142,8 @@
 /area/eris/maintenance/section2deck4central)
 "bpe" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -30246,8 +30240,8 @@
 /area/eris/neotheology/storage)
 "bpp" = (
 /obj/structure/morgue{
-	icon_state = "morgue1";
-	dir = 8
+	dir = 8;
+	icon_state = "morgue1"
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -30616,22 +30610,22 @@
 /area/eris/maintenance/section4deck4port)
 "bqk" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
 "bql" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (NORTH)";
+	dir = 1;
 	icon_state = "pipe-u";
-	dir = 1
+	tag = "icon-pipe-u (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
@@ -30673,17 +30667,17 @@
 /area/eris/command/courtroom)
 "bqq" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
 "bqr" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -30822,14 +30816,14 @@
 /area/eris/maintenance/section3deck1central)
 "bqN" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (NORTH)";
+	dir = 1;
 	icon_state = "pipe-u";
-	dir = 1
+	tag = "icon-pipe-u (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -30853,25 +30847,25 @@
 /area/eris/maintenance/section1deck3central)
 "bqT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
 "bqU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
 "bqV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
@@ -30893,9 +30887,9 @@
 /area/eris/maintenance/section3deck1central)
 "bqY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
@@ -30949,9 +30943,9 @@
 /area/eris/command/courtroom)
 "brf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -30998,9 +30992,9 @@
 /area/eris/rnd/podbay)
 "brk" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -31030,14 +31024,14 @@
 /area/eris/maintenance/section2deck4central)
 "brp" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (NORTH)";
+	dir = 1;
 	icon_state = "pipe-u";
-	dir = 1
+	tag = "icon-pipe-u (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -31049,9 +31043,9 @@
 /area/eris/maintenance/section2deck4starboard)
 "brq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
@@ -31071,31 +31065,31 @@
 /area/eris/maintenance/section1deck3central)
 "bru" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck4port)
 "brv" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck4port)
@@ -31140,22 +31134,22 @@
 /area/eris/maintenance/section2deck4starboard)
 "brC" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (NORTH)";
+	dir = 1;
 	icon_state = "pipe-d";
-	dir = 1
+	tag = "icon-pipe-d (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section2deck4port)
 "brD" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -31189,17 +31183,17 @@
 /area/eris/security/warden)
 "brH" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
 "brI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
@@ -31228,9 +31222,9 @@
 /area/eris/maintenance/section4deck4port)
 "brM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
@@ -31306,10 +31300,10 @@
 /area/eris/rnd/lab)
 "brY" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck4port)
@@ -31328,10 +31322,10 @@
 /area/eris/crew_quarters/librarybackroom)
 "bsc" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck4port)
@@ -31456,9 +31450,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck4port)
@@ -31667,10 +31661,10 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -31765,6 +31759,7 @@
 /area/eris/quartermaster/hangarsupply)
 "btl" = (
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Main";
 	capacity = 5e+006;
 	charge = 5e+006;
 	cur_coils = 4;
@@ -31773,12 +31768,11 @@
 	input_level_max = 5e+006;
 	output_attempt = 1;
 	output_level = 5e+006;
-	output_level_max = 5e+006;
-	RCon_tag = "Bioreactor - Main"
+	output_level_max = 5e+006
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -31795,6 +31789,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Main";
 	capacity = 5e+006;
 	charge = 5e+006;
 	cur_coils = 4;
@@ -31803,8 +31798,7 @@
 	input_level_max = 5e+006;
 	output_attempt = 1;
 	output_level = 5e+006;
-	output_level_max = 5e+006;
-	RCon_tag = "Bioreactor - Main"
+	output_level_max = 5e+006
 	},
 /turf/simulated/floor/plating,
 /area/eris/neotheology/bioreactor)
@@ -31867,14 +31861,14 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Core";
 	charge = 5e+006;
 	input_attempt = 1;
 	input_level = 250000;
 	inputting = 1;
 	output_attempt = 1;
 	output_level = 250000;
-	outputting = 0;
-	RCon_tag = "Bioreactor - Core"
+	outputting = 0
 	},
 /turf/simulated/floor/plating,
 /area/eris/neotheology/bioreactor)
@@ -31897,9 +31891,9 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
@@ -32029,15 +32023,15 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
@@ -32052,10 +32046,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
@@ -32121,23 +32115,23 @@
 "btT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
 "btU" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (EAST)";
+	dir = 4;
 	icon_state = "pipe-u";
-	dir = 4
+	tag = "icon-pipe-u (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
@@ -32147,17 +32141,17 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
 "btW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
@@ -32218,16 +32212,16 @@
 	},
 /obj/machinery/light/small,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
@@ -32359,17 +32353,17 @@
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (EAST)";
+	dir = 4;
 	icon_state = "danger";
-	dir = 4
+	tag = "icon-danger (EAST)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/command/teleporter)
 "buy" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -32398,9 +32392,9 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (WEST)";
+	dir = 8;
 	icon_state = "danger";
-	dir = 8
+	tag = "icon-danger (WEST)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/command/teleporter)
@@ -32447,9 +32441,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -32571,8 +32565,8 @@
 /area/eris/engineering/atmoscontrol)
 "buX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/command/teleporter)
@@ -32595,9 +32589,9 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/industrial/danger/corner{
-	tag = "icon-dangercorner (EAST)";
+	dir = 4;
 	icon_state = "dangercorner";
-	dir = 4
+	tag = "icon-dangercorner (EAST)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/command/teleporter)
@@ -32613,9 +32607,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
@@ -32626,9 +32620,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (NORTH)";
+	dir = 1;
 	icon_state = "danger";
-	dir = 1
+	tag = "icon-danger (NORTH)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/command/teleporter)
@@ -32652,9 +32646,9 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (NORTH)";
+	dir = 1;
 	icon_state = "danger";
-	dir = 1
+	tag = "icon-danger (NORTH)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/command/teleporter)
@@ -32698,17 +32692,17 @@
 /area/eris/maintenance/section3deck1central)
 "bvm" = (
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (NORTH)";
+	dir = 1;
 	icon_state = "danger";
-	dir = 1
+	tag = "icon-danger (NORTH)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/command/teleporter)
 "bvn" = (
 /obj/effect/floor_decal/industrial/danger/corner{
-	tag = "icon-dangercorner (WEST)";
+	dir = 8;
 	icon_state = "dangercorner";
-	dir = 8
+	tag = "icon-dangercorner (WEST)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/command/teleporter)
@@ -32717,10 +32711,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -32746,8 +32740,8 @@
 /obj/item/weapon/tank/oxygen,
 /obj/item/clothing/mask/gas,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/command/teleporter)
@@ -32862,14 +32856,14 @@
 /area/eris/rnd/lab)
 "bvG" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (EAST)";
+	dir = 4;
 	icon_state = "pipe-u";
-	dir = 4
+	tag = "icon-pipe-u (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 16;
@@ -33162,8 +33156,8 @@
 /area/eris/security/lobby)
 "bwk" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/security/lobby)
@@ -33371,10 +33365,10 @@
 "bwE" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -33647,10 +33641,10 @@
 "bxj" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -33721,8 +33715,8 @@
 /area/eris/crew_quarters/clothingstorage)
 "bxt" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/landmark/storyevent/hidden_vent_antag,
 /turf/simulated/floor/tiled/steel,
@@ -33812,8 +33806,8 @@
 /area/eris/engineering/atmoscontrol)
 "bxF" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/holoposter{
 	pixel_y = -32
@@ -33842,8 +33836,8 @@
 	pixel_x = -32
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -33906,15 +33900,15 @@
 /area/eris/maintenance/section3deck1central)
 "bxN" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck1central)
@@ -34055,9 +34049,9 @@
 /area/eris/hallway/main/section2)
 "byd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/landmark/join/late/cyborg,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -34079,16 +34073,16 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section2)
 "byh" = (
 /obj/machinery/computer/drone_control{
-	tag = "icon-computer (WEST)";
+	dir = 8;
 	icon_state = "computer";
-	dir = 8
+	tag = "icon-computer (WEST)"
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/eris/engineering/drone_fabrication)
@@ -34134,8 +34128,8 @@
 /area/eris/medical/surgery)
 "bym" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section2)
@@ -34207,8 +34201,8 @@
 	pixel_x = 28
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section2)
@@ -34218,8 +34212,8 @@
 /area/eris/hallway/main/section2)
 "byw" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j1"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -34396,18 +34390,18 @@
 /area/eris/engineering/drone_fabrication)
 "byV" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "byW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -34446,9 +34440,9 @@
 /area/eris/hallway/main/section4)
 "bzb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section4)
@@ -34460,19 +34454,19 @@
 /area/eris/engineering/drone_fabrication)
 "bzd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section4)
 "bze" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
@@ -34531,16 +34525,16 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section4)
 "bzm" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -34567,9 +34561,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section4)
@@ -34595,9 +34589,9 @@
 /area/eris/hallway/main/section4)
 "bzr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section4)
@@ -34632,17 +34626,17 @@
 	pixel_x = -32
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section4)
 "bzw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section4)
@@ -34655,9 +34649,9 @@
 /area/eris/maintenance/section1deck4central)
 "bzy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section4)
@@ -34669,9 +34663,9 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section4)
@@ -34695,10 +34689,10 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -34793,10 +34787,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -35259,14 +35253,14 @@
 /area/eris/maintenance/section3deck1central)
 "bAJ" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
@@ -35278,9 +35272,9 @@
 /area/eris/engineering/drone_fabrication)
 "bAL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/structure/disposalpipe/segment,
@@ -35353,14 +35347,14 @@
 /area/eris/maintenance/section3deck1central)
 "bAW" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -35427,9 +35421,9 @@
 /area/eris/maintenance/section3deck1central)
 "bBd" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/plating/under,
@@ -35488,8 +35482,8 @@
 "bBm" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck4central)
@@ -35597,16 +35591,16 @@
 /area/eris/maintenance/section3deck1central)
 "bBz" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck1central)
 "bBA" = (
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -35624,8 +35618,8 @@
 /area/eris/engineering/atmos)
 "bBD" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck4central)
@@ -35663,14 +35657,14 @@
 /area/eris/maintenance/section4deck4central)
 "bBH" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -35749,8 +35743,8 @@
 /area/eris/quartermaster/hangarsupply)
 "bBS" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -35760,8 +35754,8 @@
 /area/eris/neotheology/bioreactor)
 "bBT" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -35803,8 +35797,8 @@
 /area/eris/neotheology/bioreactor)
 "bBX" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -35904,15 +35898,15 @@
 /area/eris/maintenance/section1deck3central)
 "bCk" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
@@ -35939,10 +35933,10 @@
 /area/eris/command/teleporter)
 "bCo" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5starboard)
@@ -36013,8 +36007,8 @@
 "bCy" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/dirt,
 /area/eris/crew_quarters/hydroponics/garden)
@@ -36154,8 +36148,8 @@
 /area/eris/maintenance/section1deck3central)
 "bCT" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/random/flora/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -36163,8 +36157,8 @@
 "bCU" = (
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck4central)
@@ -36187,10 +36181,10 @@
 /area/eris/crew_quarters/bar)
 "bCW" = (
 /obj/structure/computerframe{
-	tag = "icon-0 (NORTH)";
-	icon_state = "0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "0";
+	tag = "icon-0 (NORTH)"
 	},
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/eris/maintenance/section1deck3central)
@@ -36265,9 +36259,9 @@
 "bDj" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
@@ -36297,9 +36291,9 @@
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/engineering/atmos)
@@ -36356,9 +36350,9 @@
 	pixel_y = 27
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/engineering/atmos)
@@ -36385,9 +36379,9 @@
 /area/eris/rnd/docking)
 "bDA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -36407,9 +36401,9 @@
 /area/eris/rnd/docking)
 "bDC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -36562,8 +36556,8 @@
 /area/eris/rnd/docking)
 "bDW" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/security/lobby)
@@ -36599,10 +36593,10 @@
 /area/eris/rnd/docking)
 "bEa" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -36617,10 +36611,10 @@
 /area/eris/maintenance/section3deck4port)
 "bEc" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/security/prison)
@@ -36670,9 +36664,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -36723,9 +36717,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -36792,9 +36786,9 @@
 /area/eris/rnd/xenobiology)
 "bEs" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -36986,9 +36980,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/sign/atmos_air{
 	pixel_y = 32
@@ -37130,9 +37124,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4central)
@@ -37141,9 +37135,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/contraband/low_chance,
 /turf/simulated/floor/plating/under,
@@ -37158,9 +37152,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/sign/atmos_waste{
 	pixel_y = -32
@@ -37216,16 +37210,16 @@
 "bFj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/rnd/anomalisolthree)
 "bFk" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
@@ -37260,8 +37254,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/rnd/anomalisolthree)
@@ -37276,9 +37270,9 @@
 /area/eris/command/tcommsat/chamber)
 "bFq" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -37309,23 +37303,23 @@
 "bFt" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/engineering/atmos)
 "bFu" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -37350,15 +37344,15 @@
 /area/eris/maintenance/section4deck4central)
 "bFw" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -37371,9 +37365,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4central)
@@ -37464,9 +37458,9 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4central)
@@ -37523,8 +37517,8 @@
 /area/eris/command/tcommsat/chamber)
 "bFQ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/telecomms/bus/preset_four,
 /turf/simulated/floor/bluegrid{
@@ -37540,8 +37534,8 @@
 	use_power = 0
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/rnd/anomalisolthree)
@@ -37585,10 +37579,10 @@
 /area/eris/maintenance/section2deck1port)
 "bFX" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -37726,10 +37720,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -37738,9 +37732,9 @@
 /area/eris/maintenance/section4deck4central)
 "bGo" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j2";
-	dir = 1
+	tag = "icon-pipe-j2 (NORTH)"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -37812,17 +37806,17 @@
 	dir = 8
 	},
 /obj/item/modular_computer/console/preset/engineering{
-	tag = "icon-console (WEST)";
+	dir = 8;
 	icon_state = "console";
-	dir = 8
+	tag = "icon-console (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/section4)
 "bGu" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -38119,9 +38113,9 @@
 /area/eris/hallway/side/atmosphericshallway)
 "bHe" = (
 /obj/structure/disposaloutlet{
-	tag = "icon-outlet (WEST)";
+	dir = 8;
 	icon_state = "outlet";
-	dir = 8
+	tag = "icon-outlet (WEST)"
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -38183,10 +38177,10 @@
 /area/eris/maintenance/substation/section4)
 "bHl" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -38199,9 +38193,9 @@
 /area/eris/maintenance/section4deck4port)
 "bHo" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -38403,14 +38397,14 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4central)
@@ -38485,9 +38479,9 @@
 /area/eris/maintenance/section4deck4central)
 "bHJ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/disposalpipe/sortjunction/wildcard,
 /turf/simulated/floor/plating/under,
@@ -38511,14 +38505,14 @@
 /area/eris/command/tcommsat/computer)
 "bHO" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
@@ -38628,45 +38622,45 @@
 /area/eris/engineering/atmos)
 "bHX" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/atmos)
 "bHY" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/atmos)
 "bHZ" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/atmos)
 "bIa" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/atmos)
 "bIb" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/hallway/main/section4)
@@ -38683,9 +38677,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -38723,10 +38717,10 @@
 "bIh" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4central)
@@ -38788,9 +38782,9 @@
 "bIp" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/atmos)
@@ -38819,18 +38813,18 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/atmos)
 "bIu" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/sign/department/atmos{
 	pixel_y = 32
@@ -38840,9 +38834,9 @@
 "bIv" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -38852,9 +38846,9 @@
 "bIw" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "maint_hatch_atmos2";
@@ -39062,9 +39056,9 @@
 /area/eris/maintenance/section1deck3central)
 "bIM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/drone_fabrication)
@@ -39096,9 +39090,9 @@
 /area/eris/engineering/atmos)
 "bIR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/atmos)
@@ -39211,9 +39205,9 @@
 /area/eris/maintenance/section4deck4port)
 "bJe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/item/device/radio/intercom{
 	dir = 2;
@@ -39232,10 +39226,10 @@
 /area/eris/command/tcommsat/chamber)
 "bJg" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -39266,25 +39260,25 @@
 /area/eris/engineering/engine_room)
 "bJk" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/engine_room)
 "bJl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/atmos)
 "bJm" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/atmos)
@@ -39316,25 +39310,25 @@
 /area/eris/engineering/atmoscontrol)
 "bJq" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/atmos)
 "bJr" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/atmos)
@@ -39346,9 +39340,9 @@
 "bJt" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -39457,15 +39451,15 @@
 /area/eris/maintenance/section4deck4central)
 "bJD" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -39569,9 +39563,9 @@
 "bJN" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/atmos)
@@ -39694,9 +39688,9 @@
 "bKd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/engine_room)
@@ -39826,8 +39820,8 @@
 /area/eris/engineering/construction)
 "bKq" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -39887,10 +39881,10 @@
 /area/eris/maintenance/section4deck4port)
 "bKu" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -39911,14 +39905,14 @@
 /area/eris/maintenance/section4deck4port)
 "bKw" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -39929,9 +39923,9 @@
 /area/eris/maintenance/section4deck4port)
 "bKx" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -39987,9 +39981,9 @@
 /area/eris/engineering/atmos)
 "bKF" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -40032,10 +40026,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -40059,9 +40053,9 @@
 /area/eris/maintenance/section4deck4central)
 "bKL" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/structure/cable{
 	d1 = 32;
@@ -40144,9 +40138,9 @@
 /area/eris/security/inspectors_office)
 "bKU" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck4central)
@@ -40158,14 +40152,14 @@
 /area/eris/command/tcommsat/chamber)
 "bKW" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (NORTH)";
+	dir = 1;
 	icon_state = "pipe-d";
-	dir = 1
+	tag = "icon-pipe-d (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck4central)
@@ -40202,9 +40196,9 @@
 /area/eris/maintenance/section4deck4port)
 "bLc" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/atmos)
@@ -40293,9 +40287,9 @@
 /area/eris/maintenance/section4deck4port)
 "bLk" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j1";
-	dir = 1
+	tag = "icon-pipe-j1 (NORTH)"
 	},
 /obj/machinery/door/airlock/multi_tile/metal/mait{
 	name = "Central Maintenance"
@@ -40345,9 +40339,9 @@
 "bLo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -40478,17 +40472,17 @@
 /area/eris/maintenance/section4deck4port)
 "bLD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
 "bLE" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck4port)
@@ -40571,9 +40565,9 @@
 "bLO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -40678,9 +40672,9 @@
 /area/eris/engineering/atmos)
 "bMc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/computer/cryopod/robot{
 	pixel_y = 30
@@ -40692,9 +40686,9 @@
 /area/eris/engineering/drone_fabrication)
 "bMd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -40702,17 +40696,17 @@
 /area/eris/engineering/drone_fabrication)
 "bMe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/drone_fabrication)
 "bMf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/drone_fabrication)
@@ -40866,9 +40860,9 @@
 /area/eris/engineering/propulsion/right)
 "bMu" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section1deck3central)
@@ -40878,9 +40872,9 @@
 /area/eris/maintenance/section4deck4port)
 "bMw" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -40899,9 +40893,9 @@
 /area/eris/maintenance/section4deck4port)
 "bMy" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -40927,9 +40921,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -41017,10 +41011,10 @@
 "bMK" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -41068,18 +41062,18 @@
 /area/eris/maintenance/section4deck4port)
 "bMP" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (EAST)";
+	dir = 4;
 	icon_state = "pipe-u";
-	dir = 4
+	tag = "icon-pipe-u (EAST)"
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d1 = 16;
@@ -41178,17 +41172,17 @@
 /area/eris/maintenance/section4deck4port)
 "bMZ" = (
 /obj/structure/cryofeed{
-	tag = "icon-cryo_rear (EAST)";
+	dir = 4;
 	icon_state = "cryo_rear";
-	dir = 4
+	tag = "icon-cryo_rear (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/sleep/cryo)
 "bNa" = (
 /obj/machinery/cryopod{
-	tag = "icon-cryopod_0 (EAST)";
+	dir = 4;
 	icon_state = "cryopod_0";
-	dir = 4
+	tag = "icon-cryopod_0 (EAST)"
 	},
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -41238,17 +41232,17 @@
 /area/eris/maintenance/section4deck4port)
 "bNh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
 "bNi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -41378,14 +41372,14 @@
 /area/eris/security/barracks)
 "bNw" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -41410,9 +41404,9 @@
 /area/eris/maintenance/section4deck4port)
 "bNx" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -41457,9 +41451,9 @@
 /area/eris/security/barracks)
 "bNC" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -41585,9 +41579,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -41640,9 +41634,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /turf/simulated/floor/plating/under,
@@ -41659,9 +41653,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -41676,9 +41670,9 @@
 	icon_state = "16-0"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -41690,9 +41684,9 @@
 "bNZ" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -41713,9 +41707,9 @@
 /area/eris/maintenance/section4deck4port)
 "bOb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -41809,9 +41803,9 @@
 "bOm" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -41823,9 +41817,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -41844,9 +41838,9 @@
 /area/eris/security/inspectors_office)
 "bOq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -41866,10 +41860,10 @@
 	pixel_y = 32
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -41906,18 +41900,18 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
 "bOx" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -41949,14 +41943,14 @@
 /area/eris/maintenance/section1deck3central)
 "bOB" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -41982,9 +41976,9 @@
 /area/eris/maintenance/section4deck4port)
 "bOE" = (
 /obj/machinery/cryopod{
-	tag = "icon-cryopod_0 (EAST)";
+	dir = 4;
 	icon_state = "cryopod_0";
-	dir = 4
+	tag = "icon-cryopod_0 (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/sleep/cryo)
@@ -42015,9 +42009,9 @@
 /area/eris/maintenance/section4deck4port)
 "bOJ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -42056,9 +42050,9 @@
 /area/eris/security/inspectors_office)
 "bOQ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -42091,9 +42085,9 @@
 /area/eris/maintenance/section4deck4port)
 "bOU" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -42210,8 +42204,8 @@
 /area/eris/crew_quarters/sleep/cryo)
 "bPj" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-y";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-y"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -42268,9 +42262,9 @@
 /area/eris/maintenance/substation/engineering)
 "bPp" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /obj/structure/cable/green{
@@ -42330,9 +42324,9 @@
 /area/eris/maintenance/section1deck3central)
 "bPv" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -42452,15 +42446,15 @@
 /area/eris/maintenance/section4deck4port)
 "bPH" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -42554,9 +42548,9 @@
 /area/eris/engineering/drone_fabrication)
 "bPT" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -42565,15 +42559,15 @@
 /area/eris/maintenance/section4deck4port)
 "bPU" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/contraband/low_chance,
 /turf/simulated/floor/plating/under,
@@ -42587,14 +42581,14 @@
 /area/eris/maintenance/section4deck4port)
 "bPW" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (NORTH)";
+	dir = 1;
 	icon_state = "pipe-u";
-	dir = 1
+	tag = "icon-pipe-u (NORTH)"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -42606,9 +42600,9 @@
 /area/eris/maintenance/section1deck3central)
 "bPX" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
@@ -42693,15 +42687,15 @@
 /area/eris/neotheology/bioreactor)
 "bQh" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /obj/structure/cable/green{
@@ -42747,9 +42741,9 @@
 "bQm" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/random/pack/machine,
 /obj/random/pack/tech_loot/low_chance,
@@ -42888,9 +42882,9 @@
 /area/eris/engineering/drone_fabrication)
 "bQI" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j1";
-	dir = 1
+	tag = "icon-pipe-j1 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -42929,9 +42923,9 @@
 /area/eris/maintenance/substation/engineering)
 "bQL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -42960,14 +42954,14 @@
 /area/eris/engineering/construction)
 "bQO" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -43013,9 +43007,9 @@
 /area/eris/crew_quarters/hydroponics/garden)
 "bQV" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck4port)
@@ -43031,9 +43025,9 @@
 /area/eris/crew_quarters/hydroponics/garden)
 "bQX" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -43044,8 +43038,8 @@
 /area/eris/maintenance/section4deck4port)
 "bQY" = (
 /obj/structure/bed/chair/comfy/lime{
-	icon_state = "comfychair_preview";
-	dir = 4
+	dir = 4;
+	icon_state = "comfychair_preview"
 	},
 /turf/simulated/floor/grass,
 /area/eris/crew_quarters/hydroponics)
@@ -43061,9 +43055,9 @@
 /area/eris/maintenance/substation/engineering)
 "bRb" = (
 /obj/item/modular_computer/console/preset/engineering{
-	tag = "icon-console (WEST)";
+	dir = 8;
 	icon_state = "console";
-	dir = 8
+	tag = "icon-console (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/engineering)
@@ -43100,9 +43094,9 @@
 /area/eris/crew_quarters/hydroponics)
 "bRh" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 16;
@@ -43117,8 +43111,8 @@
 /area/eris/maintenance/section3deck5starboard)
 "bRi" = (
 /obj/structure/bed/chair/comfy/lime{
-	icon_state = "comfychair_preview";
-	dir = 8
+	dir = 8;
+	icon_state = "comfychair_preview"
 	},
 /turf/simulated/floor/grass,
 /area/eris/crew_quarters/hydroponics)
@@ -43219,9 +43213,9 @@
 /area/eris/maintenance/section4deck4port)
 "bRu" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5starboard)
@@ -43234,9 +43228,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section1)
 "bRw" = (
@@ -43341,9 +43335,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section1)
 "bRE" = (
@@ -43482,8 +43476,8 @@
 "bRT" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/clothingstorage)
@@ -43593,9 +43587,9 @@
 /area/eris/crew_quarters/clothingstorage)
 "bSh" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck3central)
@@ -43665,14 +43659,14 @@
 /area/eris/maintenance/section1deck3central)
 "bSq" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (NORTH)";
+	dir = 1;
 	icon_state = "pipe-d";
-	dir = 1
+	tag = "icon-pipe-d (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -43680,29 +43674,29 @@
 	icon_state = "32-1"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section1deck3central)
 "bSr" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (NORTH)";
+	dir = 1;
 	icon_state = "pipe-d";
-	dir = 1
+	tag = "icon-pipe-d (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section1deck3central)
@@ -44002,9 +43996,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section1)
 "bTe" = (
@@ -44028,9 +44022,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section1)
 "bTg" = (
@@ -44104,9 +44098,9 @@
 /area/eris/engineering/atmos)
 "bTp" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -44223,9 +44217,9 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section3)
 "bTD" = (
@@ -44323,9 +44317,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3starboard)
@@ -44342,9 +44336,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3starboard)
@@ -44405,8 +44399,8 @@
 	pixel_y = 0
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -44476,9 +44470,9 @@
 /area/eris/security/lobby)
 "bUd" = (
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section1)
 "bUe" = (
@@ -44486,9 +44480,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section1)
 "bUf" = (
@@ -44587,14 +44581,14 @@
 /area/eris/hallway/main/section1)
 "bUr" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (EAST)";
+	dir = 4;
 	icon_state = "pipe-u";
-	dir = 4
+	tag = "icon-pipe-u (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
@@ -44688,9 +44682,9 @@
 /area/eris/maintenance/section3deck5starboard)
 "bUC" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5starboard)
@@ -44783,9 +44777,9 @@
 /area/eris/crew_quarters/hydroponics)
 "bUR" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (NORTH)";
+	dir = 1;
 	icon_state = "wooden_chair";
-	dir = 1
+	tag = "icon-wooden_chair (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -44850,9 +44844,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section1)
 "bVd" = (
@@ -44881,9 +44875,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section1)
 "bVg" = (
@@ -44963,9 +44957,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section1)
 "bVp" = (
@@ -45031,9 +45025,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section1)
 "bVw" = (
@@ -45068,8 +45062,8 @@
 /area/eris/security/lobby)
 "bVA" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -45135,9 +45129,9 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section1)
 "bVH" = (
@@ -45191,9 +45185,9 @@
 "bVO" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section1)
 "bVP" = (
@@ -45201,9 +45195,9 @@
 	dir = 8
 	},
 /obj/machinery/computer/rdservercontrol{
-	tag = "icon-computer (EAST)";
+	dir = 4;
 	icon_state = "computer";
-	dir = 4
+	tag = "icon-computer (EAST)"
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "maint_hatch_rndservers";
@@ -45216,9 +45210,9 @@
 /area/eris/rnd/server)
 "bVQ" = (
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section1)
 "bVR" = (
@@ -45408,9 +45402,9 @@
 /area/eris/maintenance/section2deck4port)
 "bWo" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair";
-	dir = 8
+	tag = "icon-wooden_chair (WEST)"
 	},
 /obj/structure/noticeboard{
 	pixel_y = 30
@@ -45438,9 +45432,9 @@
 	pixel_x = -28
 	},
 /obj/machinery/computer/message_monitor{
-	tag = "icon-computer (EAST)";
+	dir = 4;
 	icon_state = "computer";
-	dir = 4
+	tag = "icon-computer (EAST)"
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/rnd/server)
@@ -45499,9 +45493,9 @@
 /obj/machinery/atmospherics/unary/freezer{
 	dir = 2;
 	icon_state = "freezer_1";
-	use_power = 1;
 	power_setting = 20;
-	set_temperature = 73
+	set_temperature = 73;
+	use_power = 1
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/rnd/server)
@@ -45510,9 +45504,9 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section1)
 "bWy" = (
@@ -45551,9 +45545,9 @@
 /area/eris/rnd/server)
 "bWD" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair";
-	dir = 4
+	tag = "icon-wooden_chair (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -45577,9 +45571,9 @@
 /area/eris/security/inspectors_office)
 "bWF" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair";
-	dir = 8
+	tag = "icon-wooden_chair (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -45734,9 +45728,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/tiled/white/danger,
 /area/eris/rnd/mixing)
@@ -45748,8 +45742,8 @@
 /area/eris/rnd/mixing)
 "bWX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -45766,9 +45760,9 @@
 /area/eris/security/inspectors_office)
 "bWZ" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair";
-	dir = 8
+	tag = "icon-wooden_chair (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -45784,8 +45778,8 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/carpet,
 /area/eris/security/inspectors_office)
@@ -45886,9 +45880,9 @@
 "bXo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section1)
 "bXp" = (
@@ -46062,18 +46056,18 @@
 "bXM" = (
 /obj/structure/table/woodentable,
 /obj/item/device/camera{
-	name = "detectives camera";
 	desc = "A one use - polaroid camera. 30 photos left.";
+	name = "detectives camera";
+	pictures_left = 30;
 	pixel_x = 0;
-	pixel_y = 0;
-	pictures_left = 30
+	pixel_y = 0
 	},
 /obj/item/device/camera{
-	name = "detectives camera";
 	desc = "A one use - polaroid camera. 30 photos left.";
+	name = "detectives camera";
+	pictures_left = 30;
 	pixel_x = 0;
-	pixel_y = 0;
-	pictures_left = 30
+	pixel_y = 0
 	},
 /obj/item/device/camera_film,
 /obj/item/device/camera_film,
@@ -46271,16 +46265,16 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
@@ -46363,10 +46357,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
@@ -46421,9 +46415,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
@@ -46528,9 +46522,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
@@ -46547,17 +46541,17 @@
 /area/eris/command/tcommsat/chamber)
 "bYN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/neotheology/bioreactor)
 "bYO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/neotheology/bioreactor)
@@ -46706,9 +46700,9 @@
 "bZf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section2)
 "bZg" = (
@@ -46739,9 +46733,9 @@
 /area/eris/security/lobby)
 "bZj" = (
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section2)
 "bZk" = (
@@ -46796,9 +46790,9 @@
 /area/turret_protected/ai)
 "bZp" = (
 /obj/machinery/flasher{
+	id = "AI";
 	pixel_x = 0;
-	pixel_y = 24;
-	id = "AI"
+	pixel_y = 24
 	},
 /obj/machinery/light{
 	dir = 1
@@ -46854,9 +46848,9 @@
 /area/turret_protected/ai)
 "bZv" = (
 /obj/machinery/flasher{
+	id = "AI";
 	pixel_x = 0;
-	pixel_y = 24;
-	id = "AI"
+	pixel_y = 24
 	},
 /obj/machinery/light{
 	dir = 1
@@ -46939,9 +46933,9 @@
 /area/eris/quartermaster/hangarsupply)
 "bZC" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -47060,8 +47054,8 @@
 /area/eris/neotheology/bioreactor)
 "bZT" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -47076,8 +47070,8 @@
 /area/turret_protected/ai)
 "bZV" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -47122,9 +47116,9 @@
 "caa" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section2)
 "cab" = (
@@ -47155,9 +47149,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section2)
 "cag" = (
@@ -47165,15 +47159,15 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section2)
 "cah" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/bioreactor)
@@ -47191,17 +47185,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section2)
 "cak" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section2)
 "cal" = (
@@ -47322,9 +47316,9 @@
 /area/eris/hallway/main/section2)
 "caF" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down{
 	dir = 4
@@ -47391,8 +47385,8 @@
 /obj/structure/table/standard,
 /obj/machinery/recharger,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/neotheology/storage)
@@ -47481,8 +47475,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/eris/command/tcommsat/chamber)
@@ -47536,9 +47530,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section2)
 "cbh" = (
@@ -47673,9 +47667,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section2)
 "cbv" = (
@@ -47744,8 +47738,8 @@
 /area/eris/quartermaster/hangarsupply)
 "cbC" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -47812,8 +47806,8 @@
 /area/turret_protected/ai)
 "cbJ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -47842,8 +47836,8 @@
 /area/eris/command/tcommsat/chamber)
 "cbM" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -47888,9 +47882,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section2)
 "cbQ" = (
@@ -47901,9 +47895,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section2)
 "cbR" = (
@@ -47918,9 +47912,9 @@
 /area/eris/quartermaster/hangarsupply)
 "cbT" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/bioreactor)
@@ -47998,9 +47992,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section2)
 "ccf" = (
@@ -48011,9 +48005,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section2)
 "ccg" = (
@@ -48031,9 +48025,9 @@
 /area/eris/engineering/engine_room)
 "cch" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/neotheology/bioreactor)
@@ -48422,10 +48416,10 @@
 "ccY" = (
 /obj/random/scrap/sparse_weighted,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -48502,8 +48496,8 @@
 	pixel_x = -28
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/clothingstorage)
@@ -48631,9 +48625,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -48693,9 +48687,9 @@
 /area/eris/neotheology/storage)
 "cdF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -48992,9 +48986,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section2)
 "cei" = (
@@ -49075,9 +49069,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section2)
 "ces" = (
@@ -49158,10 +49152,10 @@
 	icon_state = "0-4"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
@@ -49351,10 +49345,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -49416,9 +49410,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
@@ -49462,8 +49456,8 @@
 	id = "Bluespace_Biosyphon"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/security/main)
@@ -49624,9 +49618,9 @@
 /area/eris/quartermaster/hangarsupply)
 "cft" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/neotheology/bioreactor)
@@ -49669,30 +49663,30 @@
 /area/eris/maintenance/section2deck3starboard)
 "cfx" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section2deck3starboard)
 "cfy" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (NORTH)";
+	dir = 1;
 	icon_state = "pipe-d";
-	dir = 1
+	tag = "icon-pipe-d (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section2deck3starboard)
 "cfz" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -49715,9 +49709,9 @@
 /area/eris/command/captain)
 "cfB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/neotheology/bioreactor)
@@ -49770,9 +49764,9 @@
 /area/eris/rnd/mixing)
 "cfI" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down{
 	dir = 4
@@ -49790,14 +49784,14 @@
 /area/eris/maintenance/section1deck2central)
 "cfK" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -49863,9 +49857,9 @@
 /area/eris/storage/tech)
 "cfS" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -50906,8 +50900,8 @@
 /area/eris/rnd/scient)
 "ciA" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/storage/tech)
@@ -50975,10 +50969,10 @@
 /area/eris/rnd/server)
 "ciK" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
@@ -51018,30 +51012,30 @@
 /area/eris/crew_quarters/janitor)
 "ciQ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
 "ciR" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
@@ -51114,9 +51108,9 @@
 /area/eris/rnd/lab)
 "cjb" = (
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (WEST)";
+	dir = 8;
 	icon_state = "danger";
-	dir = 8
+	tag = "icon-danger (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/mixing)
@@ -51219,19 +51213,19 @@
 "cjn" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
 "cjo" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
@@ -51309,9 +51303,9 @@
 /area/eris/medical/patients_rooms)
 "cjy" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/rnd/server)
@@ -51353,9 +51347,9 @@
 "cjE" = (
 /obj/structure/lattice,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
@@ -51422,10 +51416,10 @@
 "cjL" = (
 /obj/structure/lattice,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
@@ -51435,8 +51429,8 @@
 /area/eris/crew_quarters/bar)
 "cjN" = (
 /obj/structure/bed/chair/custom/bar_special{
-	icon_state = "bar_chair";
-	dir = 4
+	dir = 4;
+	icon_state = "bar_chair"
 	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
@@ -51452,10 +51446,10 @@
 "cjP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -51491,8 +51485,8 @@
 /area/eris/rnd/mixing)
 "cjU" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/mixing)
@@ -51508,19 +51502,19 @@
 /area/eris/rnd/mixing)
 "cjW" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/eris/rnd/mixing)
 "cjX" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
@@ -51636,9 +51630,9 @@
 /area/eris/rnd/server)
 "ckl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/server)
@@ -51649,8 +51643,8 @@
 /area/eris/rnd/server)
 "ckn" = (
 /obj/structure/bed/chair/custom/bar_special{
-	icon_state = "bar_chair";
-	dir = 1
+	dir = 1;
+	icon_state = "bar_chair"
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/eris/crew_quarters/bar)
@@ -51750,8 +51744,8 @@
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/rnd/mixing)
@@ -51807,9 +51801,9 @@
 /area/eris/rnd/lab)
 "ckH" = (
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (EAST)";
+	dir = 4;
 	icon_state = "danger";
-	dir = 4
+	tag = "icon-danger (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/lab)
@@ -51855,9 +51849,9 @@
 "ckN" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/eris/rnd/mixing)
@@ -51926,9 +51920,9 @@
 /area/eris/quartermaster/storage)
 "ckX" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
@@ -52050,8 +52044,8 @@
 /area/eris/engineering/engine_room)
 "clq" = (
 /obj/structure/bed/chair/custom/bar_special{
-	icon_state = "bar_chair";
-	dir = 4
+	dir = 4;
+	icon_state = "bar_chair"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel/bar_light,
@@ -52309,10 +52303,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4port)
@@ -52343,8 +52337,8 @@
 /area/eris/neotheology/chapelritualroom)
 "clZ" = (
 /obj/structure/bed/chair/custom/bar_special{
-	icon_state = "bar_chair";
-	dir = 4
+	dir = 4;
+	icon_state = "bar_chair"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -52369,9 +52363,9 @@
 "cmb" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/medical/medbay)
@@ -52406,9 +52400,9 @@
 "cmg" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/medical/medbay)
@@ -52461,8 +52455,8 @@
 /area/eris/rnd/mixing)
 "cmo" = (
 /obj/structure/bed/chair/custom/bar_special{
-	icon_state = "bar_chair";
-	dir = 8
+	dir = 8;
+	icon_state = "bar_chair"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -52516,10 +52510,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4port)
@@ -52535,9 +52529,9 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (WEST)";
+	dir = 8;
 	icon_state = "danger";
-	dir = 8
+	tag = "icon-danger (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/mixing)
@@ -52556,9 +52550,9 @@
 /area/eris/command/mbo)
 "cmA" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/rnd/lab)
@@ -52576,16 +52570,16 @@
 	dir = 10
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4port)
@@ -52731,9 +52725,9 @@
 /area/eris/medical/surgery)
 "cmX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -52778,9 +52772,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (WEST)";
+	dir = 8;
 	icon_state = "danger";
-	dir = 8
+	tag = "icon-danger (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/mixing)
@@ -52836,9 +52830,9 @@
 /area/eris/rnd/mixing)
 "cnm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/machinery/camera/network/research{
 	dir = 4
@@ -53112,8 +53106,8 @@
 /area/eris/medical/psych)
 "cnO" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper_0";
-	dir = 4
+	dir = 4;
+	icon_state = "sleeper_0"
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -53159,8 +53153,8 @@
 	id = null
 	},
 /obj/effect/floor_decal/industrial/warning/cee{
-	icon_state = "warningcee";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcee"
 	},
 /turf/simulated/floor/reinforced{
 	name = "engine floor";
@@ -53209,9 +53203,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (WEST)";
+	dir = 8;
 	icon_state = "danger";
-	dir = 8
+	tag = "icon-danger (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/mixing)
@@ -53222,9 +53216,9 @@
 "coc" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/rnd/lab)
@@ -53240,8 +53234,8 @@
 "cof" = (
 /obj/structure/railing,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/open,
 /area/eris/rnd/lab)
@@ -53280,12 +53274,12 @@
 /area/eris/command/meo)
 "col" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper_0";
-	dir = 4
+	dir = 4;
+	icon_state = "sleeper_0"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/medical/medbay)
@@ -53298,9 +53292,9 @@
 /area/eris/crew_quarters/hydroponics/garden)
 "con" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair";
-	dir = 8
+	tag = "icon-wooden_chair (WEST)"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/neotheology/chapel)
@@ -53343,9 +53337,9 @@
 	pixel_y = -21
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/eris/rnd/mixing)
@@ -53406,10 +53400,10 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -53594,10 +53588,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -53621,8 +53615,8 @@
 /area/eris/medical/reception)
 "coW" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/structure/closet/custodial,
@@ -53774,9 +53768,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (WEST)";
+	dir = 8;
 	icon_state = "danger";
-	dir = 8
+	tag = "icon-danger (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/mixing)
@@ -53786,9 +53780,9 @@
 "cpp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section3)
 "cpq" = (
@@ -53810,9 +53804,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section3)
 "cps" = (
@@ -53981,15 +53975,15 @@
 /area/eris/engineering/engine_room)
 "cpM" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/neotheology/chapel)
@@ -54033,22 +54027,22 @@
 /area/eris/medical/reception)
 "cpS" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/neotheology/chapel)
 "cpT" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/neotheology/chapel)
@@ -54065,9 +54059,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (WEST)";
+	dir = 8;
 	icon_state = "danger";
-	dir = 8
+	tag = "icon-danger (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/mixing)
@@ -54102,8 +54096,8 @@
 /area/eris/neotheology/chapel)
 "cqc" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/neotheology/chapelritualroom)
@@ -54128,10 +54122,10 @@
 "cqg" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/neotheology/chapel)
@@ -54142,9 +54136,9 @@
 "cqi" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/neotheology/chapel)
@@ -54161,16 +54155,16 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -54185,9 +54179,9 @@
 /area/eris/neotheology/chapel)
 "cqm" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-y (EAST)";
+	dir = 4;
 	icon_state = "pipe-y";
-	dir = 4
+	tag = "icon-pipe-y (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
@@ -54202,9 +54196,9 @@
 	pixel_y = 21
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/eris/rnd/mixing)
@@ -54448,14 +54442,14 @@
 /area/eris/maintenance/section3deck3port)
 "cqQ" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -54499,60 +54493,60 @@
 /area/eris/rnd/lab)
 "cqY" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/rnd/lab)
 "cqZ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/rnd/lab)
 "cra" = (
 /obj/structure/lattice,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/rnd/lab)
 "crb" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/rnd/lab)
 "crc" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (NORTH)";
+	dir = 1;
 	icon_state = "pipe-u";
-	dir = 1
+	tag = "icon-pipe-u (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 16;
@@ -54656,9 +54650,9 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -54670,9 +54664,9 @@
 	pixel_y = 0
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j2";
-	dir = 1
+	tag = "icon-pipe-j2 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -54739,9 +54733,9 @@
 /area/eris/command/meo)
 "cry" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
@@ -54799,8 +54793,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -54873,8 +54867,8 @@
 	pixel_x = 28
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -55205,9 +55199,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -55218,9 +55212,9 @@
 "csJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section3)
 "csK" = (
@@ -55337,29 +55331,29 @@
 /area/eris/neotheology/chapel)
 "ctd" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/open,
 /area/eris/neotheology/chapel)
 "cte" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/open,
@@ -55378,9 +55372,9 @@
 /area/eris/neotheology/chapel)
 "cth" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair";
-	dir = 8
+	tag = "icon-wooden_chair (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -55486,10 +55480,10 @@
 "ctx" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/open,
@@ -55538,9 +55532,9 @@
 "ctC" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/open,
@@ -55676,8 +55670,8 @@
 "ctX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "maint_hatch_cargo_bay";
@@ -55784,8 +55778,8 @@
 	pixel_x = -28
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/hallway/side/bridgehallway)
@@ -55975,8 +55969,8 @@
 /area/eris/crew_quarters/bar)
 "cuK" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -55989,8 +55983,8 @@
 "cuL" = (
 /obj/item/device/radio/beacon,
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -55999,12 +55993,12 @@
 /area/eris/command/meo)
 "cuM" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/command/meo)
@@ -56118,10 +56112,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4port)
@@ -56290,8 +56284,8 @@
 /area/eris/hallway/side/bridgehallway)
 "cvD" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -56323,9 +56317,9 @@
 /area/eris/maintenance/section1deck4central)
 "cvI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck2central)
@@ -56395,8 +56389,8 @@
 	pixel_x = -28
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -56573,9 +56567,9 @@
 /area/eris/engineering/engine_room)
 "cwn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck2central)
@@ -56821,24 +56815,24 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section1deck2central)
 "cwP" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56854,10 +56848,10 @@
 /area/eris/engineering/engeva)
 "cwR" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -56867,10 +56861,10 @@
 /area/eris/quartermaster/storage)
 "cwS" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56901,15 +56895,15 @@
 /area/eris/engineering/post)
 "cwW" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56991,8 +56985,8 @@
 /area/eris/quartermaster/storage)
 "cxd" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -57154,9 +57148,9 @@
 /area/eris/neotheology/chapel)
 "cxv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/space,
 /area/space)
@@ -57165,9 +57159,9 @@
 /area/eris/maintenance/section4deck3port)
 "cxx" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /turf/space,
 /area/space)
@@ -57181,9 +57175,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck2central)
@@ -57360,8 +57354,8 @@
 	dir = 4
 	},
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -57462,10 +57456,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -57575,10 +57569,10 @@
 /area/eris/engineering/post)
 "cyr" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -57590,9 +57584,9 @@
 /area/eris/quartermaster/storage)
 "cyt" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -57690,17 +57684,17 @@
 /area/eris/maintenance/section1deck4central)
 "cyI" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck2central)
 "cyK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -57711,9 +57705,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -57743,9 +57737,9 @@
 /area/eris/engineering/engine_room)
 "cyP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -57856,18 +57850,18 @@
 /area/eris/quartermaster/office)
 "czd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "cze" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	tag = "icon-map (WEST)";
+	dir = 8;
 	icon_state = "map";
-	dir = 8
+	tag = "icon-map (WEST)"
 	},
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/plating/under,
@@ -57877,9 +57871,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section1deck4central)
@@ -57888,9 +57882,9 @@
 /area/eris/neotheology/chapel)
 "czh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -57902,9 +57896,9 @@
 /area/eris/maintenance/section1deck2central)
 "czi" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -57924,9 +57918,9 @@
 /area/eris/maintenance/oldtele)
 "czk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -58112,9 +58106,9 @@
 	},
 /obj/machinery/camera/network/engineering,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -58335,9 +58329,9 @@
 "cAb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/security/lobby)
 "cAc" = (
@@ -58358,9 +58352,9 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/security/lobby)
 "cAf" = (
@@ -58437,9 +58431,9 @@
 /area/eris/maintenance/section3deck4starboard)
 "cAo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
@@ -58455,17 +58449,17 @@
 /area/eris/crew_quarters/bar)
 "cAq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
 "cAr" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
@@ -58515,9 +58509,9 @@
 /area/eris/crew_quarters/bar)
 "cAx" = (
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section3)
 "cAy" = (
@@ -58525,15 +58519,15 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -58772,10 +58766,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating/under,
@@ -58784,16 +58778,16 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cBa" = (
 /obj/structure/railing/grey{
-	icon_state = "grey_railing0";
-	dir = 1
+	dir = 1;
+	icon_state = "grey_railing0"
 	},
 /turf/simulated/floor/bluegrid,
 /area/eris/crew_quarters/bar)
@@ -58904,10 +58898,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4port)
@@ -58932,9 +58926,9 @@
 /area/eris/neotheology/chapelritualroom)
 "cBn" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (NORTH)";
+	dir = 1;
 	icon_state = "pipe-d";
-	dir = 1
+	tag = "icon-pipe-d (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
@@ -59005,10 +58999,10 @@
 /area/eris/maintenance/section3deck4central)
 "cBu" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -59023,10 +59017,10 @@
 /area/eris/maintenance/section1deck2central)
 "cBw" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -59159,26 +59153,26 @@
 /area/eris/quartermaster/storage)
 "cBM" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cBN" = (
 /obj/random/scrap/sparse_weighted,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -59208,17 +59202,17 @@
 /area/eris/maintenance/section1deck2central)
 "cBR" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j1";
-	dir = 1
+	tag = "icon-pipe-j1 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -59291,9 +59285,9 @@
 /area/eris/hallway/side/bridgehallway)
 "cCa" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (WEST)";
+	dir = 8;
 	icon_state = "pipe-d";
-	dir = 8
+	tag = "icon-pipe-d (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck4central)
@@ -59303,9 +59297,9 @@
 /area/eris/maintenance/section3deck4starboard)
 "cCc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
@@ -59412,9 +59406,9 @@
 /area/eris/crew_quarters/kitchen)
 "cCn" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -59590,8 +59584,8 @@
 /area/eris/crew_quarters/kitchen)
 "cCz" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/grass,
 /area/eris/crew_quarters/hydroponics)
@@ -59630,10 +59624,10 @@
 "cCE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
@@ -59670,10 +59664,10 @@
 "cCK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
@@ -59687,10 +59681,10 @@
 /area/eris/hallway/side/bridgehallway)
 "cCM" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
@@ -59715,8 +59709,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -59779,9 +59773,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section3)
 "cCX" = (
@@ -59807,10 +59801,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4port)
@@ -59887,8 +59881,8 @@
 /area/eris/maintenance/section3deck4central)
 "cDk" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -59984,10 +59978,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -60049,9 +60043,9 @@
 /area/eris/crew_quarters/fitness)
 "cDE" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -60070,8 +60064,8 @@
 /area/eris/command/exultant/quarters)
 "cDG" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-01";
-	icon_state = "plant-01"
+	icon_state = "plant-01";
+	tag = "icon-plant-01"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 28
@@ -60198,9 +60192,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/structure/sign/atmos_air{
 	pixel_y = 32
@@ -60209,10 +60203,10 @@
 /area/eris/maintenance/section4deck3port)
 "cDV" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -60231,14 +60225,14 @@
 /area/eris/command/meo)
 "cDX" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -60253,10 +60247,10 @@
 /area/eris/maintenance/section4deck3port)
 "cDY" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/hallway/main/section2)
@@ -60413,9 +60407,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -60442,9 +60436,9 @@
 /area/eris/maintenance/section3deck4central)
 "cEx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	tag = "icon-map (WEST)";
+	dir = 8;
 	icon_state = "map";
-	dir = 8
+	tag = "icon-map (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -60596,9 +60590,9 @@
 /area/eris/command/exultant/quarters)
 "cEP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -60621,22 +60615,22 @@
 /area/eris/maintenance/section3deck3port)
 "cES" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
 "cET" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (WEST)";
+	dir = 8;
 	icon_state = "pipe-d";
-	dir = 8
+	tag = "icon-pipe-d (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -60644,9 +60638,9 @@
 	icon_state = "32-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/open,
@@ -60687,17 +60681,17 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
 "cEZ" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -60761,9 +60755,9 @@
 "cFh" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -60812,10 +60806,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4port)
@@ -60835,9 +60829,9 @@
 /area/eris/maintenance/section3deck3starboard)
 "cFq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -60871,10 +60865,10 @@
 /area/eris/crew_quarters/janitor)
 "cFw" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
@@ -60962,9 +60956,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -61109,14 +61103,14 @@
 /area/eris/maintenance/section1deck2central)
 "cFV" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (NORTH)";
+	dir = 1;
 	icon_state = "pipe-d";
-	dir = 1
+	tag = "icon-pipe-d (NORTH)"
 	},
 /obj/structure/cable{
 	d1 = 32;
@@ -61148,21 +61142,21 @@
 /area/eris/quartermaster/office)
 "cGa" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/section3starboard)
 "cGb" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (WEST)";
+	dir = 8;
 	icon_state = "pipe-d";
-	dir = 8
+	tag = "icon-pipe-d (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -61200,9 +61194,9 @@
 /area/eris/rnd/storage)
 "cGh" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section1deck2central)
@@ -61229,18 +61223,18 @@
 /area/eris/maintenance/section2deck3port)
 "cGm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
 "cGn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/sign/atmos_waste{
 	pixel_y = -32
@@ -61467,9 +61461,9 @@
 /area/eris/engineering/post)
 "cGI" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck3port)
@@ -61671,9 +61665,9 @@
 /area/turret_protected/ai)
 "cHi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck2central)
@@ -61913,18 +61907,18 @@
 /area/eris/security/checkpoint/science)
 "cHL" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section1deck4central)
 "cHM" = (
 /obj/structure/computerframe{
-	tag = "icon-0 (NORTH)";
-	icon_state = "0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "0";
+	tag = "icon-0 (NORTH)"
 	},
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/engineering/post)
@@ -61950,17 +61944,17 @@
 /area/eris/maintenance/section1deck4central)
 "cHR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck2central)
 "cHS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck2central)
@@ -62135,8 +62129,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/command/bridge)
@@ -62169,9 +62163,9 @@
 /area/eris/maintenance/section2deck2starboard)
 "cIt" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -62238,10 +62232,10 @@
 /area/eris/hallway/side/bridgehallway)
 "cIG" = (
 /obj/structure/computerframe{
-	tag = "icon-0 (EAST)";
-	icon_state = "0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "0";
+	tag = "icon-0 (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck2starboard)
@@ -62251,8 +62245,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics)
@@ -62368,9 +62362,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section4)
 "cIY" = (
@@ -62456,17 +62450,17 @@
 "cJh" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/hallway/main/section2)
 "cJi" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/buildable{
 	charge = 5e+006;
@@ -62618,8 +62612,8 @@
 /area/eris/maintenance/section2deck2starboard)
 "cJE" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/sign/sec4{
 	pixel_x = 32
@@ -62660,9 +62654,9 @@
 	icon_state = "16-0"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -62703,14 +62697,14 @@
 /area/eris/maintenance/section2deck2port)
 "cJM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section4)
 "cJN" = (
@@ -62736,8 +62730,8 @@
 /area/eris/crew_quarters/sleep/cryo)
 "cJQ" = (
 /obj/structure/bed/chair/custom/bar_special{
-	icon_state = "bar_chair";
-	dir = 1
+	dir = 1;
+	icon_state = "bar_chair"
 	},
 /obj/machinery/light/small{
 	dir = 4;
@@ -62917,9 +62911,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -62936,9 +62930,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -63098,9 +63092,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -63108,10 +63102,10 @@
 "cKG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -63130,9 +63124,9 @@
 /area/eris/maintenance/section2deck2port)
 "cKK" = (
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section4)
 "cKL" = (
@@ -63159,9 +63153,9 @@
 /area/eris/engineering/engine_room)
 "cKO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -63349,24 +63343,24 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section4)
 "cLn" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/hallway/main/section2)
 "cLo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -63389,15 +63383,15 @@
 /area/eris/engineering/foyer)
 "cLr" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/hallway/main/section2)
@@ -63548,9 +63542,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
@@ -63575,9 +63569,9 @@
 "cLQ" = (
 /obj/machinery/atmospherics/pipe/zpipe/up,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /obj/machinery/button/remote/blast_door{
@@ -63705,9 +63699,9 @@
 "cMh" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	tag = "icon-map (WEST)";
+	dir = 8;
 	icon_state = "map";
-	dir = 8
+	tag = "icon-map (WEST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -63734,9 +63728,9 @@
 /area/eris/engineering/engine_room)
 "cMl" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -63746,9 +63740,9 @@
 /area/eris/maintenance/section2deck2starboard)
 "cMn" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -63757,14 +63751,14 @@
 /area/eris/engineering/engine_room)
 "cMp" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -63850,9 +63844,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section4)
 "cMB" = (
@@ -63868,9 +63862,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section4)
 "cMC" = (
@@ -63946,9 +63940,9 @@
 /area/eris/rnd/storage)
 "cMQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -63969,9 +63963,9 @@
 /area/eris/storage/primary)
 "cMT" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	tag = "icon-map (WEST)";
+	dir = 8;
 	icon_state = "map";
-	dir = 8
+	tag = "icon-map (WEST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -63982,23 +63976,23 @@
 /area/eris/maintenance/section2deck2starboard)
 "cMV" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
 "cMW" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /obj/structure/cable/cyan{
@@ -64059,8 +64053,8 @@
 	pixel_x = 28
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -64092,10 +64086,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/hallway/main/section4)
@@ -64178,9 +64172,9 @@
 /area/eris/rnd/storage)
 "cNs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -64230,9 +64224,9 @@
 "cNz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
@@ -64529,29 +64523,29 @@
 /area/eris/engineering/engine_room)
 "cOl" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
 "cOm" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
-	icon_state = "down";
-	dir = 1
-	},
-/obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
 	dir = 1;
-	anchored = 1
+	icon_state = "down";
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	anchored = 1;
+	dir = 1;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (NORTH)"
+	},
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
@@ -64630,9 +64624,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section4)
 "cOx" = (
@@ -64653,9 +64647,9 @@
 /area/eris/quartermaster/storage)
 "cOz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -64952,9 +64946,9 @@
 /area/eris/engineering/breakroom)
 "cPn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -65000,14 +64994,14 @@
 /area/eris/engineering/breakroom)
 "cPs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section4)
 "cPt" = (
@@ -65019,14 +65013,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section4)
 "cPu" = (
@@ -65124,9 +65118,9 @@
 /area/shuttle/mining/station)
 "cPH" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck4port)
@@ -65226,9 +65220,9 @@
 "cPW" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
@@ -65310,9 +65304,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section4)
 "cQh" = (
@@ -65503,8 +65497,8 @@
 "cQC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "12,20"
@@ -65573,9 +65567,9 @@
 /area/eris/medical/genetics)
 "cQK" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down{
 	dir = 4
@@ -65584,18 +65578,18 @@
 /area/eris/maintenance/section2deck2port)
 "cQL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
 "cQM" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck4port)
@@ -65687,8 +65681,8 @@
 /obj/item/device/lighting/glowstick/flare,
 /obj/item/device/lighting/glowstick/flare,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/structure/sign/sec4{
 	pixel_x = 32
@@ -65900,9 +65894,9 @@
 /area/eris/rnd/xenobiology)
 "cRw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -65947,9 +65941,9 @@
 "cRD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -65961,33 +65955,33 @@
 /area/eris/crew_quarters/sleep/cryo)
 "cRF" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/engine_room)
 "cRG" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/engine_room)
@@ -66240,9 +66234,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /turf/simulated/floor/plating/under,
@@ -66390,15 +66384,15 @@
 /area/shuttle/mining/station)
 "cSP" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -66408,34 +66402,34 @@
 "cSQ" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/engine_room)
 "cSR" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/engine_room)
@@ -66451,9 +66445,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
@@ -66492,9 +66486,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /obj/structure/cable{
 	d1 = 32;
@@ -66696,9 +66690,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
@@ -66843,10 +66837,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -66868,9 +66862,9 @@
 /area/eris/command/bridgebar)
 "cTT" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/hull{
 	flooring_override = "hullcenter18";
@@ -66880,9 +66874,9 @@
 /area/space)
 "cTU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/hull{
 	flooring_override = "hullcenter18";
@@ -66915,12 +66909,12 @@
 /area/eris/security/checkpoint/supply)
 "cTX" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-01";
-	icon_state = "plant-01"
+	icon_state = "plant-01";
+	tag = "icon-plant-01"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/command/meeting_room)
@@ -66942,12 +66936,12 @@
 /area/eris/hallway/main/section2)
 "cUa" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-21";
-	icon_state = "plant-21"
+	icon_state = "plant-21";
+	tag = "icon-plant-21"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/command/meeting_room)
@@ -67107,9 +67101,9 @@
 /area/space)
 "cUx" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/hull,
 /area/space)
@@ -67246,26 +67240,26 @@
 /area/shuttle/mining/station)
 "cUR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
 "cUS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
 "cUT" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
@@ -67321,9 +67315,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	tag = "icon-map (WEST)";
+	dir = 8;
 	icon_state = "map";
-	dir = 8
+	tag = "icon-map (WEST)"
 	},
 /obj/random/lowkeyrandom/low_chance,
 /obj/random/lowkeyrandom/low_chance,
@@ -67336,9 +67330,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
@@ -67349,9 +67343,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -67376,9 +67370,9 @@
 	},
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /turf/simulated/floor/plating/under,
@@ -67399,9 +67393,9 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
@@ -67503,9 +67497,9 @@
 /area/shuttle/mining/station)
 "cVx" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -67520,9 +67514,9 @@
 /area/eris/maintenance/section4deck3port)
 "cVy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (NORTH)";
+	dir = 1;
 	icon_state = "intact";
-	dir = 1
+	tag = "icon-intact (NORTH)"
 	},
 /turf/simulated/wall,
 /area/eris/maintenance/section4deck3port)
@@ -67558,8 +67552,8 @@
 /area/eris/command/captain)
 "cVB" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -67568,9 +67562,9 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	tag = "icon-map (WEST)";
+	dir = 8;
 	icon_state = "map";
-	dir = 8
+	tag = "icon-map (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
@@ -67585,9 +67579,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/plating/under,
@@ -67613,10 +67607,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating/under,
@@ -67629,10 +67623,10 @@
 /area/eris/hallway/main/section2)
 "cVI" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
@@ -67917,8 +67911,8 @@
 /area/eris/maintenance/section3deck4starboard)
 "cWt" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-17";
-	icon_state = "plant-17"
+	icon_state = "plant-17";
+	tag = "icon-plant-17"
 	},
 /obj/machinery/camera/network/command{
 	dir = 4
@@ -67927,8 +67921,8 @@
 /area/eris/command/meeting_room)
 "cWu" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-17";
-	icon_state = "plant-17"
+	icon_state = "plant-17";
+	tag = "icon-plant-17"
 	},
 /obj/machinery/camera/network/command{
 	dir = 8
@@ -67987,9 +67981,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/side/cryo)
 "cWB" = (
@@ -68001,9 +67995,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/side/cryo)
 "cWC" = (
@@ -68040,14 +68034,14 @@
 /area/eris/maintenance/section4deck3port)
 "cWG" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (NORTH)";
+	dir = 1;
 	icon_state = "pipe-u";
-	dir = 1
+	tag = "icon-pipe-u (NORTH)"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -68059,9 +68053,9 @@
 /area/eris/maintenance/section4deck3port)
 "cWH" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -68176,10 +68170,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
@@ -68189,10 +68183,10 @@
 /area/eris/maintenance/section4deck3port)
 "cXb" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -68278,8 +68272,8 @@
 	amount = 120
 	},
 /obj/structure/window/basic{
-	icon_state = "window";
-	dir = 4
+	dir = 4;
+	icon_state = "window"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/hallway/side/section3starboard)
@@ -68353,9 +68347,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/side/cryo)
 "cXt" = (
@@ -68497,8 +68491,8 @@
 /area/eris/command/meo/quarters)
 "cXK" = (
 /obj/structure/bed/chair/custom/bar_special{
-	icon_state = "bar_chair";
-	dir = 8
+	dir = 8;
+	icon_state = "bar_chair"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -68707,20 +68701,20 @@
 "cYf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
@@ -68771,9 +68765,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/side/cryo)
 "cYk" = (
@@ -68782,9 +68776,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/side/cryo)
 "cYl" = (
@@ -68822,15 +68816,15 @@
 /area/eris/command/fo/quarters)
 "cYo" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -69020,18 +69014,18 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
 "cYN" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down{
 	dir = 4
@@ -69045,8 +69039,8 @@
 /area/eris/maintenance/section3deck3starboard)
 "cYO" = (
 /obj/structure/bed/chair/custom/bar_special{
-	icon_state = "bar_chair";
-	dir = 4
+	dir = 4;
+	icon_state = "bar_chair"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -69074,9 +69068,9 @@
 /area/eris/maintenance/section1deck2central)
 "cYR" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (NORTH)";
+	dir = 1;
 	icon_state = "pipe-u";
-	dir = 1
+	tag = "icon-pipe-u (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4port)
@@ -69100,15 +69094,15 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -69147,8 +69141,8 @@
 	pixel_y = 0
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/table/steel,
 /obj/machinery/recharger,
@@ -69556,9 +69550,9 @@
 /area/eris/medical/medbay/iso)
 "cZT" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
@@ -69583,8 +69577,8 @@
 /area/eris/command/meo/quarters)
 "cZX" = (
 /obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
+	dir = 1;
+	icon_state = "warning"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -69600,14 +69594,14 @@
 /area/eris/maintenance/substation/section3)
 "cZY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
@@ -69625,9 +69619,9 @@
 /area/eris/maintenance/section4deck3port)
 "dab" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (NORTH)";
+	dir = 1;
 	icon_state = "term";
-	dir = 1
+	tag = "icon-term (NORTH)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -69690,6 +69684,7 @@
 /area/shuttle/mining/station)
 "daj" = (
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Hulk Mining Barge";
 	charge = 1.5e+007;
 	cur_coils = 3;
 	input_attempt = 1;
@@ -69697,8 +69692,7 @@
 	input_level_max = 750000;
 	output_attempt = 1;
 	output_level = 750000;
-	output_level_max = 750000;
-	RCon_tag = "Hulk Mining Barge"
+	output_level_max = 750000
 	},
 /obj/structure/cable,
 /turf/simulated/floor,
@@ -69775,10 +69769,10 @@
 "daw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating/under,
@@ -69803,8 +69797,8 @@
 /area/eris/medical/medbay/iso)
 "day" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
+	dir = 1;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/section3)
@@ -69858,8 +69852,8 @@
 /area/shuttle/mining/station)
 "daG" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -69953,9 +69947,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -70003,8 +69997,8 @@
 /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "7,3"
@@ -70088,18 +70082,18 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck3port)
 "dbn" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck3port)
@@ -70393,10 +70387,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
@@ -70463,15 +70457,15 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -70531,10 +70525,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -70554,9 +70548,9 @@
 	dir = 5
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
@@ -70568,9 +70562,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
@@ -70591,9 +70585,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
@@ -70654,8 +70648,8 @@
 /area/eris/command/captain)
 "dcA" = (
 /obj/machinery/shower{
-	icon_state = "shower";
-	dir = 4
+	dir = 4;
+	icon_state = "shower"
 	},
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -70671,9 +70665,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70691,9 +70685,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j2";
-	dir = 1
+	tag = "icon-pipe-j2 (NORTH)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -70717,9 +70711,9 @@
 /area/eris/rnd/anomal)
 "dcF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -70794,9 +70788,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -70830,10 +70824,10 @@
 "dcS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -70868,10 +70862,10 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -71017,10 +71011,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -71102,8 +71096,8 @@
 /area/eris/command/captain)
 "ddA" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-01";
-	icon_state = "plant-01"
+	icon_state = "plant-01";
+	tag = "icon-plant-01"
 	},
 /obj/item/device/radio/intercom{
 	dir = 2;
@@ -71361,9 +71355,9 @@
 /area/eris/rnd/anomal)
 "ddW" = (
 /obj/machinery/power/emitter/anchored{
-	tag = "icon-emitter (NORTH)";
+	dir = 1;
 	icon_state = "emitter";
-	dir = 1
+	tag = "icon-emitter (NORTH)"
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -71434,12 +71428,12 @@
 /area/eris/command/bridgebar)
 "deg" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -71690,9 +71684,9 @@
 /area/eris/command/bridgebar)
 "deM" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair";
-	dir = 8
+	tag = "icon-wooden_chair (WEST)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
@@ -71796,9 +71790,9 @@
 /area/eris/command/captain)
 "deX" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair";
-	dir = 4
+	tag = "icon-wooden_chair (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -71906,9 +71900,9 @@
 /area/eris/command/bridgebar)
 "dfj" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair";
-	dir = 8
+	tag = "icon-wooden_chair (WEST)"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/newscaster{
@@ -72001,9 +71995,9 @@
 /area/eris/rnd/server)
 "dft" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair";
-	dir = 4
+	tag = "icon-wooden_chair (EAST)"
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/eris/command/captain)
@@ -72070,9 +72064,9 @@
 /area/eris/maintenance/section3deck4central)
 "dfC" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (NORTH)";
+	dir = 1;
 	icon_state = "wooden_chair";
-	dir = 1
+	tag = "icon-wooden_chair (NORTH)"
 	},
 /turf/simulated/floor/wood,
 /area/eris/command/bridgebar)
@@ -72148,9 +72142,9 @@
 /area/eris/command/captain)
 "dfL" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (EAST)";
+	dir = 4;
 	icon_state = "wooden_chair";
-	dir = 4
+	tag = "icon-wooden_chair (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -72669,8 +72663,8 @@
 /area/eris/command/meeting_room)
 "dgV" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -73096,8 +73090,8 @@
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/rd,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/eris/command/meo/quarters)
@@ -73173,8 +73167,8 @@
 /area/eris/command/meeting_room)
 "dhU" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/hallway/side/section3starboard)
@@ -73200,9 +73194,9 @@
 "dhX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -73478,9 +73472,9 @@
 /area/turret_protected/ai)
 "diD" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/turret_protected/ai)
@@ -73525,9 +73519,9 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section3)
 "diI" = (
@@ -73585,17 +73579,17 @@
 "diO" = (
 /obj/structure/railing,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/open,
 /area/turret_protected/ai)
 "diP" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/turret_protected/ai)
@@ -74185,8 +74179,8 @@
 /area/eris/security/checkpoint/science)
 "djZ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -74412,8 +74406,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -74484,26 +74478,26 @@
 /area/eris/maintenance/substation/bridge)
 "dkJ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/turret_protected/ai)
 "dkK" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/turret_protected/ai)
@@ -74534,9 +74528,9 @@
 /area/eris/command/exultant)
 "dkO" = (
 /obj/item/modular_computer/console/preset/command{
-	tag = "icon-console (WEST)";
+	dir = 8;
 	icon_state = "console";
-	dir = 8
+	tag = "icon-console (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -74595,9 +74589,9 @@
 	dir = 1
 	},
 /obj/structure/bed/chair/comfy/purp{
-	tag = "icon-comfychair_preview (EAST)";
+	dir = 4;
 	icon_state = "comfychair_preview";
-	dir = 4
+	tag = "icon-comfychair_preview (EAST)"
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/rnd/research)
@@ -74627,8 +74621,8 @@
 /area/eris/command/mbo/quarters)
 "dkY" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-03";
-	icon_state = "plant-03"
+	icon_state = "plant-03";
+	tag = "icon-plant-03"
 	},
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -74689,9 +74683,9 @@
 	dir = 6
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -74708,9 +74702,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -74750,10 +74744,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -74861,9 +74855,9 @@
 	pixel_x = 22
 	},
 /obj/structure/bed/chair/comfy/purp{
-	tag = "icon-comfychair_preview (WEST)";
+	dir = 8;
 	icon_state = "comfychair_preview";
-	dir = 8
+	tag = "icon-comfychair_preview (WEST)"
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/rnd/research)
@@ -74892,9 +74886,9 @@
 /area/eris/security/checkpoint/science)
 "dlv" = (
 /obj/structure/bed/chair/comfy/purp{
-	tag = "icon-comfychair_preview (EAST)";
+	dir = 4;
 	icon_state = "comfychair_preview";
-	dir = 4
+	tag = "icon-comfychair_preview (EAST)"
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/rnd/research)
@@ -74973,16 +74967,16 @@
 "dlG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -74995,16 +74989,16 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -75036,9 +75030,9 @@
 /area/eris/medical/medbay/iso)
 "dlM" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/turret_protected/ai)
@@ -75048,9 +75042,9 @@
 	pixel_y = 0
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/turret_protected/ai)
@@ -75081,8 +75075,8 @@
 /area/eris/command/tcommsat/chamber)
 "dlS" = (
 /obj/structure/bed/chair/comfy/teal{
-	icon_state = "comfychair_teal";
-	dir = 4
+	dir = 4;
+	icon_state = "comfychair_teal"
 	},
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -75098,9 +75092,9 @@
 /area/eris/rnd/research)
 "dlU" = (
 /obj/structure/bed/chair/comfy/purp{
-	tag = "icon-comfychair_preview (WEST)";
+	dir = 8;
 	icon_state = "comfychair_preview";
-	dir = 8
+	tag = "icon-comfychair_preview (WEST)"
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/rnd/research)
@@ -75110,9 +75104,9 @@
 /area/eris/rnd/research)
 "dlW" = (
 /obj/structure/bed/chair/comfy/purp{
-	tag = "icon-comfychair_preview (NORTH)";
+	dir = 1;
 	icon_state = "comfychair_preview";
-	dir = 1
+	tag = "icon-comfychair_preview (NORTH)"
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/rnd/research)
@@ -75134,9 +75128,9 @@
 /area/eris/command/exultant/quarters)
 "dlZ" = (
 /obj/structure/bed/chair/comfy/purp{
-	tag = "icon-comfychair_preview (NORTH)";
+	dir = 1;
 	icon_state = "comfychair_preview";
-	dir = 1
+	tag = "icon-comfychair_preview (NORTH)"
 	},
 /obj/structure/sign/faction/moebius{
 	pixel_y = -32
@@ -75164,9 +75158,9 @@
 /area/eris/command/mbo/quarters)
 "dmd" = (
 /obj/item/modular_computer/console/preset/command{
-	tag = "icon-console (WEST)";
+	dir = 8;
 	icon_state = "console";
-	dir = 8
+	tag = "icon-console (WEST)"
 	},
 /turf/simulated/floor/wood,
 /area/eris/command/mbo/quarters)
@@ -75241,9 +75235,9 @@
 /area/eris/hallway/main/section2)
 "dmp" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/hallway/main/section2)
@@ -75268,8 +75262,8 @@
 	pixel_y = -23
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-y";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/wood,
 /area/eris/command/mbo/quarters)
@@ -75335,10 +75329,10 @@
 	pixel_x = -32
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -75380,9 +75374,9 @@
 /area/eris/maintenance/section2deck2starboard)
 "dmF" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -75437,10 +75431,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -75506,9 +75500,9 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -75704,10 +75698,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -75755,10 +75749,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -75798,16 +75792,16 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -75947,10 +75941,10 @@
 "dnD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -76042,8 +76036,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/hallway/side/section3starboard)
@@ -76052,9 +76046,9 @@
 /area/eris/medical/chemistry)
 "dnR" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (WEST)";
+	dir = 8;
 	icon_state = "pipe-d";
-	dir = 8
+	tag = "icon-pipe-d (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck4starboard)
@@ -76085,10 +76079,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -76119,10 +76113,10 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
@@ -76155,10 +76149,10 @@
 /area/eris/maintenance/section2deck2starboard)
 "dod" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/sign/department/eva{
 	pixel_x = -32;
@@ -76168,10 +76162,10 @@
 /area/eris/maintenance/section2deck2port)
 "doe" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
@@ -76186,9 +76180,9 @@
 /area/eris/maintenance/section2deck2port)
 "doh" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
@@ -76291,10 +76285,10 @@
 /area/eris/medical/medeva)
 "dot" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -76351,14 +76345,14 @@
 /area/eris/maintenance/section2deck2starboard)
 "doA" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (WEST)";
+	dir = 8;
 	icon_state = "pipe-d";
-	dir = 8
+	tag = "icon-pipe-d (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -76369,9 +76363,9 @@
 /area/eris/maintenance/section2deck2starboard)
 "doB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/landmark/storyevent/midgame_stash_spawn{
 	navigation = "Section 2, floor 4. South-east of the maints, behind the glass and on the pipes."
@@ -76380,9 +76374,9 @@
 /area/eris/maintenance/section2deck2starboard)
 "doC" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section2deck2starboard)
@@ -76420,9 +76414,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -76494,10 +76488,10 @@
 	icon_state = "2-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -76570,9 +76564,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j2 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j2";
-	dir = 1
+	tag = "icon-pipe-j2 (NORTH)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -76644,17 +76638,17 @@
 /area/eris/rnd/docking)
 "dph" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section1deck1central)
 "dpi" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -76696,8 +76690,8 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/hallway/side/section3starboard)
@@ -76827,8 +76821,8 @@
 /area/eris/rnd/research)
 "dpE" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/maintenance/junk)
@@ -77010,9 +77004,9 @@
 	pixel_x = -28
 	},
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (NORTH)";
+	dir = 1;
 	icon_state = "danger";
-	dir = 1
+	tag = "icon-danger (NORTH)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/hallway/main/section2)
@@ -77260,18 +77254,18 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "dqy" = (
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (NORTHEAST)";
+	dir = 5;
 	icon_state = "danger";
-	dir = 5
+	tag = "icon-danger (NORTHEAST)"
 	},
 /obj/structure/cyberplant,
 /turf/simulated/floor/tiled/white,
@@ -77284,9 +77278,9 @@
 /area/eris/engineering/gravity_generator)
 "dqA" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -77334,10 +77328,10 @@
 /area/eris/rnd/xenobiology)
 "dqH" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/hallway/main/section2)
@@ -77473,9 +77467,9 @@
 /area/eris/security/checkpoint/science)
 "dra" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -77542,8 +77536,8 @@
 /area/eris/maintenance/section4deck2starboard)
 "drj" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section3)
@@ -77633,9 +77627,9 @@
 /area/eris/medical/chemistry)
 "drs" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/white/panels,
 /area/eris/maintenance/section3deck2starboard)
@@ -77710,9 +77704,9 @@
 /area/eris/medical/chemistry)
 "drA" = (
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (EAST)";
+	dir = 4;
 	icon_state = "danger";
-	dir = 4
+	tag = "icon-danger (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/hallway/main/section2)
@@ -77762,9 +77756,9 @@
 /area/eris/maintenance/section3deck2starboard)
 "drG" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck2starboard)
@@ -77853,17 +77847,17 @@
 /area/eris/quartermaster/storage)
 "drR" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
 "drS" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -77893,9 +77887,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (EAST)";
+	dir = 4;
 	icon_state = "danger";
-	dir = 4
+	tag = "icon-danger (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/hallway/main/section2)
@@ -77991,9 +77985,9 @@
 /area/eris/security/prisoncells)
 "dsk" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck4starboard)
@@ -78025,9 +78019,9 @@
 /area/eris/maintenance/section3deck2starboard)
 "dsp" = (
 /obj/structure/cryofeed{
-	tag = "icon-cryo_rear (EAST)";
+	dir = 4;
 	icon_state = "cryo_rear";
-	dir = 4
+	tag = "icon-cryo_rear (EAST)"
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/maintenance/section3deck2starboard)
@@ -78044,9 +78038,9 @@
 /area/eris/security/prisoncells)
 "dsr" = (
 /obj/machinery/cryopod{
-	tag = "icon-cryopod_0 (EAST)";
+	dir = 4;
 	icon_state = "cryopod_0";
-	dir = 4
+	tag = "icon-cryopod_0 (EAST)"
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/maintenance/section3deck2starboard)
@@ -78224,8 +78218,8 @@
 /area/eris/hallway/main/section2)
 "dsP" = (
 /obj/structure/morgue{
-	icon_state = "morgue1";
-	dir = 8
+	dir = 8;
+	icon_state = "morgue1"
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/security/evidencestorage)
@@ -78256,8 +78250,8 @@
 /area/eris/medical/medbay/iso)
 "dsU" = (
 /obj/structure/morgue{
-	icon_state = "morgue1";
-	dir = 8
+	dir = 8;
+	icon_state = "morgue1"
 	},
 /obj/machinery/camera/network/security{
 	dir = 1
@@ -78298,16 +78292,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -78761,8 +78755,8 @@
 /area/eris/engineering/engine_room)
 "dud" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/security/checkpoint/supply)
@@ -78864,9 +78858,9 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section2)
 "duq" = (
@@ -78891,8 +78885,8 @@
 /area/eris/medical/medbay/uppercor)
 "dur" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -79055,8 +79049,8 @@
 /area/eris/hallway/side/section3starboard)
 "duK" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -79068,8 +79062,8 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/engine_room)
@@ -79209,10 +79203,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck3port)
@@ -79253,9 +79247,9 @@
 /area/eris/rnd/research)
 "dvb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
@@ -79294,9 +79288,9 @@
 /area/eris/engineering/engine_room)
 "dvh" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck3port)
@@ -79510,10 +79504,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
@@ -79545,10 +79539,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
@@ -79740,9 +79734,9 @@
 	icon_state = "pipe-j2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -79872,9 +79866,9 @@
 "dwr" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
@@ -79887,10 +79881,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
@@ -79911,10 +79905,10 @@
 	},
 /obj/random/junk/low_chance,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
@@ -80217,9 +80211,9 @@
 /area/eris/medical/medbay)
 "dxe" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
@@ -80237,10 +80231,10 @@
 /area/eris/maintenance/oldbridge)
 "dxi" = (
 /obj/structure/computerframe{
-	tag = "icon-0 (EAST)";
-	icon_state = "0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "0";
+	tag = "icon-0 (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/eris/maintenance/oldbridge)
@@ -80252,8 +80246,8 @@
 /area/eris/maintenance/oldbridge)
 "dxk" = (
 /obj/machinery/atmospherics/binary/circulator/anchored{
-	icon_state = "circ-assembled";
-	dir = 1
+	dir = 1;
+	icon_state = "circ-assembled"
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/eris/engineering/engine_room)
@@ -80272,8 +80266,8 @@
 "dxm" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/generator/anchored{
-	icon_state = "teg-assembled";
-	dir = 4
+	dir = 4;
+	icon_state = "teg-assembled"
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/eris/engineering/engine_room)
@@ -80430,10 +80424,10 @@
 /area/eris/maintenance/oldbridge)
 "dxF" = (
 /obj/structure/computerframe{
-	tag = "icon-0 (WEST)";
-	icon_state = "0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "0";
+	tag = "icon-0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/eris/maintenance/oldbridge)
@@ -80650,8 +80644,8 @@
 	},
 /obj/structure/cable/yellow,
 /obj/machinery/power/generator/anchored{
-	icon_state = "teg-assembled";
-	dir = 4
+	dir = 4;
+	icon_state = "teg-assembled"
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/eris/engineering/engine_room)
@@ -80789,8 +80783,8 @@
 "dyE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/status_display/supply_display{
 	pixel_x = -32
@@ -80806,10 +80800,10 @@
 /area/eris/maintenance/oldbridge)
 "dyG" = (
 /obj/structure/computerframe{
-	tag = "icon-0 (NORTH)";
-	icon_state = "0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "0";
+	tag = "icon-0 (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/maintenance/oldbridge)
@@ -81030,8 +81024,8 @@
 /obj/random/medical,
 /obj/random/medical,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/reception)
@@ -81150,9 +81144,9 @@
 "dzr" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/side/cryo)
 "dzs" = (
@@ -81200,10 +81194,10 @@
 /area/eris/maintenance/section2deck2port)
 "dzy" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/command/mbo)
@@ -81256,9 +81250,9 @@
 /area/eris/command/mbo)
 "dzH" = (
 /obj/structure/bed/chair/comfy/teal{
-	tag = "icon-comfychair_preview (WEST)";
+	dir = 8;
 	icon_state = "comfychair_preview";
-	dir = 8
+	tag = "icon-comfychair_preview (WEST)"
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/command/mbo)
@@ -81322,9 +81316,9 @@
 "dzO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -81357,9 +81351,9 @@
 /area/eris/maintenance/section1deck2central)
 "dzT" = (
 /obj/structure/bed/chair/comfy/teal{
-	tag = "icon-comfychair_preview (EAST)";
+	dir = 4;
 	icon_state = "comfychair_preview";
-	dir = 4
+	tag = "icon-comfychair_preview (EAST)"
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/command/mbo)
@@ -81414,9 +81408,9 @@
 /area/eris/command/mbo)
 "dzZ" = (
 /obj/structure/bed/chair/comfy/teal{
-	tag = "icon-comfychair_preview (WEST)";
+	dir = 8;
 	icon_state = "comfychair_preview";
-	dir = 8
+	tag = "icon-comfychair_preview (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -81468,17 +81462,17 @@
 /area/eris/command/mbo)
 "dAe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck2central)
 "dAf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/wall/r_wall,
 /area/eris/maintenance/section1deck2central)
@@ -81571,32 +81565,32 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
 "dAr" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
 "dAs" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
@@ -81611,10 +81605,10 @@
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
@@ -81627,10 +81621,10 @@
 	},
 /obj/random/junk/low_chance,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
@@ -81640,10 +81634,10 @@
 "dAw" = (
 /obj/random/medical/low_chance,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
@@ -81903,17 +81897,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section2)
 "dBb" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/medical/medbay)
@@ -81944,9 +81938,9 @@
 /area/eris/engineering/engine_room)
 "dBg" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -81979,10 +81973,10 @@
 "dBl" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/medical/medbay)
@@ -82000,9 +81994,9 @@
 /area/eris/medical/medbay)
 "dBo" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -82046,9 +82040,9 @@
 /area/eris/maintenance/section1deck1central)
 "dBv" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/medical/medbay)
@@ -82214,9 +82208,9 @@
 /area/eris/rnd/mixing)
 "dBL" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawnphoron,
@@ -82385,9 +82379,9 @@
 /area/eris/medical/surgery)
 "dCe" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	tag = "icon-map (WEST)";
+	dir = 8;
 	icon_state = "map";
-	dir = 8
+	tag = "icon-map (WEST)"
 	},
 /obj/random/junk/low_chance,
 /obj/structure/cable/green{
@@ -82410,9 +82404,9 @@
 "dCg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -82446,8 +82440,8 @@
 "dCk" = (
 /obj/structure/medical_stand,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/patients_rooms)
@@ -82617,9 +82611,9 @@
 /area/eris/engineering/engine_room)
 "dCF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
@@ -82645,8 +82639,8 @@
 	pixel_y = 28
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
@@ -82677,9 +82671,9 @@
 /area/eris/rnd/mixing)
 "dCM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawnphoron,
@@ -82697,8 +82691,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/medbreak)
@@ -82895,8 +82889,8 @@
 	pixel_x = 28
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/eris/engineering/starboardhallway)
@@ -83072,9 +83066,9 @@
 /area/eris/medical/reception)
 "dDG" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-y (EAST)";
+	dir = 4;
 	icon_state = "pipe-y";
-	dir = 4
+	tag = "icon-pipe-y (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/reception)
@@ -83175,9 +83169,9 @@
 /obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section2)
 "dDT" = (
@@ -83217,8 +83211,8 @@
 /area/eris/medical/reception)
 "dDX" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -83381,8 +83375,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/medbreak)
@@ -83483,9 +83477,9 @@
 "dEE" = (
 /obj/machinery/atmospherics/pipe/zpipe/up,
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -83525,9 +83519,9 @@
 /area/eris/maintenance/section1deck1central)
 "dEJ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -83546,9 +83540,9 @@
 /area/eris/maintenance/section1deck1central)
 "dEL" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -83572,8 +83566,8 @@
 /area/eris/medical/morgue)
 "dEO" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/eris/medical/psych)
@@ -83639,9 +83633,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section2)
 "dEW" = (
@@ -83750,10 +83744,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -83929,9 +83923,9 @@
 /area/eris/hallway/side/section3port)
 "dFO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck1central)
@@ -83954,9 +83948,9 @@
 /area/eris/maintenance/section1deck1central)
 "dFS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
@@ -83979,9 +83973,9 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section3)
 "dFX" = (
@@ -84000,9 +83994,9 @@
 /area/eris/quartermaster/storage)
 "dFZ" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck3starboard)
@@ -84017,8 +84011,8 @@
 /area/eris/maintenance/section3deck3starboard)
 "dGb" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84027,14 +84021,14 @@
 /area/eris/maintenance/section3deck3starboard)
 "dGc" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (WEST)";
+	dir = 8;
 	icon_state = "pipe-d";
-	dir = 8
+	tag = "icon-pipe-d (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -84198,9 +84192,9 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section3)
 "dGz" = (
@@ -84273,17 +84267,17 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
 "dGH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
@@ -84317,9 +84311,9 @@
 /area/eris/quartermaster/miningdock)
 "dGM" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck2port)
@@ -84387,8 +84381,8 @@
 /area/eris/maintenance/section1deck1central)
 "dGX" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/hallway/side/section3port)
@@ -84499,9 +84493,9 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -84519,10 +84513,10 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -85259,9 +85253,9 @@
 /area/eris/hallway/side/atmosphericshallway)
 "dIG" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section1deck1central)
@@ -85326,9 +85320,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/security/lobby)
 "dIN" = (
@@ -85347,9 +85341,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/security/lobby)
 "dIO" = (
@@ -85361,17 +85355,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/security/lobby)
 "dIP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/security/lobby)
 "dIQ" = (
@@ -85402,9 +85396,9 @@
 /area/eris/engineering/foyer)
 "dIT" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/security/prison)
@@ -85542,9 +85536,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (WEST)";
+	dir = 8;
 	icon_state = "monofloor";
-	dir = 8
+	tag = "icon-monofloor (WEST)"
 	},
 /area/eris/hallway/main/section2)
 "dJf" = (
@@ -85573,9 +85567,9 @@
 /area/eris/engineering/breakroom)
 "dJh" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -85590,8 +85584,8 @@
 /obj/item/weapon/storage/belt/utility,
 /obj/item/weapon/storage/belt/utility,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/breakroom)
@@ -85699,14 +85693,14 @@
 /area/eris/hallway/side/section3port)
 "dJv" = (
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (EAST)";
+	dir = 4;
 	icon_state = "danger";
-	dir = 4
+	tag = "icon-danger (EAST)"
 	},
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (WEST)";
+	dir = 8;
 	icon_state = "danger";
-	dir = 8
+	tag = "icon-danger (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/misc_lab)
@@ -85760,9 +85754,9 @@
 /area/eris/engineering/propulsion/left)
 "dJC" = (
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (NORTH)";
+	dir = 1;
 	icon_state = "danger";
-	dir = 1
+	tag = "icon-danger (NORTH)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/misc_lab)
@@ -85879,14 +85873,14 @@
 /area/eris/engineering/propulsion/left)
 "dJP" = (
 /obj/effect/floor_decal/industrial/danger/corner{
-	tag = "icon-dangercorner (EAST)";
+	dir = 4;
 	icon_state = "dangercorner";
-	dir = 4
+	tag = "icon-dangercorner (EAST)"
 	},
 /obj/effect/floor_decal/industrial/danger/corner{
-	tag = "icon-dangercorner (WEST)";
+	dir = 8;
 	icon_state = "dangercorner";
-	dir = 8
+	tag = "icon-dangercorner (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/misc_lab)
@@ -85895,9 +85889,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (NORTH)";
+	dir = 1;
 	icon_state = "danger";
-	dir = 1
+	tag = "icon-danger (NORTH)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/misc_lab)
@@ -85985,9 +85979,9 @@
 /area/eris/engineering/propulsion/left)
 "dJZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/propulsion/left)
@@ -86076,10 +86070,10 @@
 /area/eris/engineering/engine_room)
 "dKj" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/hallway/main/section4)
@@ -86152,17 +86146,17 @@
 /area/eris/engineering/shield_generator)
 "dKt" = (
 /obj/machinery/button/remote/blast_door{
-	name = "Vent Engine";
-	id = "enginevent"
+	id = "enginevent";
+	name = "Vent Engine"
 	},
 /turf/simulated/wall/r_wall,
 /area/eris/engineering/engine_room)
 "dKu" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /obj/machinery/door/blast/regular{
@@ -86191,8 +86185,8 @@
 /area/eris/engineering/propulsion/right)
 "dKx" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/buildable/engine{
 	RCon_tag = "Engine - Main 1"
@@ -86201,8 +86195,8 @@
 /area/eris/engineering/engine_room)
 "dKy" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -86232,14 +86226,14 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Engine - Core";
 	charge = 5e+006;
 	input_attempt = 1;
 	input_level = 250000;
 	inputting = 1;
 	output_attempt = 1;
 	output_level = 250000;
-	outputting = 0;
-	RCon_tag = "Engine - Core"
+	outputting = 0
 	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/engine_room)
@@ -86275,9 +86269,9 @@
 /area/eris/engineering/propulsion/left)
 "dKG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -86364,9 +86358,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -86382,9 +86376,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -86406,16 +86400,16 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
 "dKR" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -86426,9 +86420,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/engine_room)
@@ -86443,9 +86437,9 @@
 /area/eris/engineering/foyer)
 "dKT" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
@@ -86464,9 +86458,9 @@
 "dKV" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
@@ -86484,10 +86478,10 @@
 /area/eris/maintenance/section1deck1central)
 "dKY" = (
 /obj/structure/computerframe{
-	tag = "icon-0 (NORTH)";
-	icon_state = "0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "0";
+	tag = "icon-0 (NORTH)"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/maintenance/section1deck1central)
@@ -86539,9 +86533,9 @@
 /area/eris/engineering/engine_room)
 "dLi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/cable/yellow{
@@ -86573,18 +86567,18 @@
 /area/eris/engineering/engine_room)
 "dLl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
 "dLm" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
@@ -86621,9 +86615,9 @@
 "dLr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
@@ -86668,9 +86662,9 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
@@ -86689,9 +86683,9 @@
 	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
@@ -86753,9 +86747,9 @@
 /area/eris/engineering/propulsion/right)
 "dLF" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -86842,9 +86836,9 @@
 "dLO" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -86876,9 +86870,9 @@
 "dLS" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
@@ -86943,8 +86937,8 @@
 /area/eris/engineering/engine_room)
 "dMb" = (
 /obj/machinery/power/generator/anchored{
-	icon_state = "teg-assembled";
-	dir = 4
+	dir = 4;
+	icon_state = "teg-assembled"
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -87002,13 +86996,13 @@
 /area/eris/engineering/engine_room)
 "dMf" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/structure/sign/fire{
 	pixel_x = 32;
@@ -87132,16 +87126,16 @@
 	icon_state = "32-4"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck4central)
@@ -87169,9 +87163,9 @@
 /area/eris/engineering/engine_room)
 "dMB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/engine_room)
@@ -87182,21 +87176,21 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/engine_room)
 "dMD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/engine_room)
@@ -87213,9 +87207,9 @@
 /area/eris/engineering/engine_room)
 "dMF" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck3starboard)
@@ -87505,9 +87499,9 @@
 	dir = 5
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -87519,14 +87513,14 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -87545,15 +87539,15 @@
 	dir = 10
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -87580,9 +87574,9 @@
 /area/eris/maintenance/section2deck1starboard)
 "dNp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1starboard)
@@ -87606,9 +87600,9 @@
 /area/eris/engineering/propulsion/right)
 "dNs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/catwalk,
 /obj/machinery/access_button{
@@ -87685,9 +87679,9 @@
 /area/eris/engineering/engine_room)
 "dNC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -87730,9 +87724,9 @@
 /area/eris/engineering/engine_room)
 "dNJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
@@ -87743,9 +87737,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -87857,9 +87851,9 @@
 /area/eris/engineering/propulsion/right)
 "dOc" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/hallway/side/section3port)
@@ -87921,10 +87915,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -87939,9 +87933,9 @@
 	pixel_y = -32
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -87952,9 +87946,9 @@
 /area/eris/maintenance/section4deck2starboard)
 "dOn" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section2deck1port)
@@ -87965,14 +87959,14 @@
 /area/eris/maintenance/section3deck3starboard)
 "dOp" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (EAST)";
+	dir = 4;
 	icon_state = "pipe-u";
-	dir = 4
+	tag = "icon-pipe-u (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
@@ -88005,19 +87999,19 @@
 "dOt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
 "dOu" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/hallway/main/section4)
@@ -88027,10 +88021,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -88043,10 +88037,10 @@
 /area/eris/maintenance/section4deck2starboard)
 "dOx" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -88067,8 +88061,8 @@
 /area/eris/rnd/misc_lab)
 "dOA" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/reinforced{
 	name = "engine floor";
@@ -88118,10 +88112,10 @@
 "dOF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -88132,23 +88126,23 @@
 /area/eris/maintenance/section4deck2starboard)
 "dOH" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
 "dOI" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -88158,9 +88152,9 @@
 "dOJ" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -88174,16 +88168,16 @@
 	icon_state = "2-4"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -88208,9 +88202,9 @@
 /area/eris/crew_quarters/bar)
 "dOP" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -88450,9 +88444,9 @@
 /area/eris/maintenance/section2deck1starboard)
 "dPv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -88685,9 +88679,9 @@
 /area/eris/medical/chemstor)
 "dQc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -88715,9 +88709,9 @@
 "dQf" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -88729,9 +88723,9 @@
 "dQg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -88749,9 +88743,9 @@
 /area/eris/maintenance/section2deck5starboard)
 "dQi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -88762,9 +88756,9 @@
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -88798,7 +88792,6 @@
 /obj/machinery/button/remote/blast_door{
 	id = "shieldroom";
 	name = "Shield Generator Shutters";
-	pixel_x = 25;
 	pixel_x = 0
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -88900,16 +88893,16 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/engine_room)
@@ -88921,10 +88914,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/engine_room)
@@ -88937,10 +88930,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/engine_room)
@@ -88959,10 +88952,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/engine_room)
@@ -88974,29 +88967,29 @@
 	dir = 10
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/engine_room)
 "dQG" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
-	icon_state = "down";
-	dir = 1
-	},
-/obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
 	dir = 1;
-	anchored = 1
+	icon_state = "down";
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	anchored = 1;
+	dir = 1;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (NORTH)"
+	},
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -89137,10 +89130,10 @@
 /area/eris/rnd/research)
 "dQY" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /obj/structure/cable/green{
@@ -89156,9 +89149,9 @@
 /area/eris/maintenance/section4deck4central)
 "dQZ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section2deck1port)
@@ -89170,10 +89163,10 @@
 /area/eris/medical/chemstor)
 "dRb" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
@@ -89210,23 +89203,23 @@
 /area/eris/engineering/engine_room)
 "dRj" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/scrap/moderate_weighted/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4central)
 "dRk" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section2deck1port)
@@ -89435,10 +89428,10 @@
 /area/eris/engineering/engeva)
 "dRK" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/engeva)
@@ -89474,9 +89467,9 @@
 /area/eris/maintenance/section3deck3starboard)
 "dRO" = (
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck3starboard)
@@ -89509,10 +89502,10 @@
 /area/eris/crew_quarters/barbackroom)
 "dRT" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
@@ -89529,8 +89522,8 @@
 /area/eris/engineering/engeva)
 "dRW" = (
 /obj/structure/railing/grey{
-	icon_state = "grey_railing0";
-	dir = 8
+	dir = 8;
+	icon_state = "grey_railing0"
 	},
 /turf/simulated/open,
 /area/eris/crew_quarters/bar)
@@ -89548,10 +89541,10 @@
 /area/eris/hallway/side/section3starboard)
 "dRY" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/open,
@@ -89575,9 +89568,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
@@ -89591,10 +89584,10 @@
 /area/eris/maintenance/section4deck2port)
 "dSe" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "maint_hatch_eng_core1";
@@ -89650,10 +89643,10 @@
 /area/eris/maintenance/section4deck2port)
 "dSl" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -89673,14 +89666,14 @@
 /area/eris/maintenance/section4deck2port)
 "dSn" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (EAST)";
+	dir = 4;
 	icon_state = "pipe-u";
-	dir = 4
+	tag = "icon-pipe-u (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
@@ -89696,9 +89689,9 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -89719,18 +89712,18 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	tag = "icon-map (WEST)";
+	dir = 8;
 	icon_state = "map";
-	dir = 8
+	tag = "icon-map (WEST)"
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
 "dSq" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -89828,9 +89821,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
@@ -89853,10 +89846,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
@@ -89945,9 +89938,9 @@
 /area/eris/maintenance/section4deck2starboard)
 "dSR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -89967,10 +89960,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -89979,10 +89972,10 @@
 	dir = 10
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -90022,9 +90015,9 @@
 "dTb" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
@@ -90034,8 +90027,8 @@
 /area/eris/maintenance/section4deck2port)
 "dTd" = (
 /obj/structure/railing/grey{
-	icon_state = "grey_railing0";
-	dir = 8
+	dir = 8;
+	icon_state = "grey_railing0"
 	},
 /obj/structure/railing/grey,
 /turf/simulated/open,
@@ -90061,10 +90054,10 @@
 "dTg" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
@@ -90088,14 +90081,14 @@
 /area/eris/maintenance/section4deck2port)
 "dTj" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (NORTH)";
+	dir = 1;
 	icon_state = "pipe-d";
-	dir = 1
+	tag = "icon-pipe-d (NORTH)"
 	},
 /obj/structure/cable{
 	d1 = 32;
@@ -90106,9 +90099,9 @@
 /area/eris/maintenance/section4deck2port)
 "dTk" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -90134,9 +90127,9 @@
 /area/eris/maintenance/section4deck2starboard)
 "dTn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -90409,9 +90402,9 @@
 /area/eris/quartermaster/misc)
 "dTY" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/open,
@@ -90421,10 +90414,10 @@
 	dir = 6
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
@@ -90513,9 +90506,9 @@
 /area/eris/engineering/breakroom)
 "dUn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
@@ -90555,10 +90548,10 @@
 "dUt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
@@ -90606,9 +90599,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
@@ -90623,10 +90616,10 @@
 "dUC" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
@@ -90708,9 +90701,9 @@
 /area/eris/maintenance/section2deck5starboard)
 "dUQ" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
@@ -91167,9 +91160,9 @@
 /area/eris/rnd/docking)
 "dVW" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (NORTH)";
+	dir = 1;
 	icon_state = "pipe-d";
-	dir = 1
+	tag = "icon-pipe-d (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck3port)
@@ -91183,9 +91176,9 @@
 /area/eris/maintenance/section3deck3port)
 "dVY" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/space,
 /area/space)
@@ -91199,10 +91192,10 @@
 /area/eris/maintenance/section3deck3port)
 "dWa" = (
 /obj/structure/computerframe{
-	tag = "icon-0 (WEST)";
-	icon_state = "0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "0";
+	tag = "icon-0 (WEST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/maintenance/section2deck1port)
@@ -91226,9 +91219,9 @@
 /area/eris/command/bridge)
 "dWe" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -91249,9 +91242,9 @@
 /area/eris/maintenance/section2deck5starboard)
 "dWg" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -91287,9 +91280,9 @@
 /area/eris/command/bridge)
 "dWj" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -91308,9 +91301,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1starboard)
@@ -91459,17 +91452,17 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1starboard)
 "dWu" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -91540,10 +91533,10 @@
 /area/eris/maintenance/section2deck1starboard)
 "dWC" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1starboard)
@@ -91569,10 +91562,10 @@
 "dWF" = (
 /obj/machinery/atmospherics/tvalve/mirrored/bypass,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1starboard)
@@ -91608,10 +91601,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1starboard)
@@ -91620,20 +91613,20 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1starboard)
 "dWL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1starboard)
@@ -91679,8 +91672,8 @@
 /area/eris/command/meeting_room)
 "dWT" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/command/meeting_room)
@@ -91690,8 +91683,8 @@
 /area/space)
 "dWV" = (
 /obj/machinery/shower{
-	icon_state = "shower";
-	dir = 4
+	dir = 4;
+	icon_state = "shower"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -91713,8 +91706,8 @@
 /area/eris/rnd/xenobiology)
 "dWW" = (
 /obj/machinery/shower{
-	icon_state = "shower";
-	dir = 8
+	dir = 8;
+	icon_state = "shower"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -91740,9 +91733,9 @@
 /area/eris/rnd/xenobiology)
 "dWX" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section2deck1starboard)
@@ -91756,8 +91749,8 @@
 "dWZ" = (
 /obj/structure/railing/grey,
 /obj/structure/railing/grey{
-	icon_state = "grey_railing0";
-	dir = 8
+	dir = 8;
+	icon_state = "grey_railing0"
 	},
 /turf/simulated/open,
 /area/eris/crew_quarters/bar)
@@ -91821,9 +91814,9 @@
 /area/eris/command/meeting_room)
 "dXh" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/open,
@@ -91897,9 +91890,9 @@
 /area/eris/rnd/docking)
 "dXp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -92005,17 +91998,17 @@
 /area/eris/storage/primary)
 "dXB" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/command/meeting_room)
 "dXC" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/command/meeting_room)
@@ -92051,18 +92044,18 @@
 /area/eris/command/meeting_room)
 "dXH" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/open,
 /area/eris/command/meeting_room)
 "dXI" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/open,
@@ -92305,9 +92298,9 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section3)
 "dYc" = (
@@ -92344,19 +92337,19 @@
 /area/eris/neotheology/chapel)
 "dYh" = (
 /obj/structure/railing/grey{
-	icon_state = "grey_railing0";
-	dir = 1
+	dir = 1;
+	icon_state = "grey_railing0"
 	},
 /obj/structure/railing/grey{
-	icon_state = "grey_railing0";
-	dir = 8
+	dir = 8;
+	icon_state = "grey_railing0"
 	},
 /turf/simulated/open,
 /area/eris/crew_quarters/bar)
 "dYi" = (
 /obj/structure/railing/grey{
-	icon_state = "grey_railing0";
-	dir = 1
+	dir = 1;
+	icon_state = "grey_railing0"
 	},
 /turf/simulated/open,
 /area/eris/crew_quarters/bar)
@@ -92370,9 +92363,9 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
@@ -92383,23 +92376,23 @@
 /area/eris/medical/genetics)
 "dYm" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
 "dYn" = (
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck4central)
@@ -92499,19 +92492,19 @@
 /area/eris/maintenance/section3deck3starboard)
 "dYy" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/eris/neotheology/chapel)
 "dYz" = (
 /obj/structure/railing/grey{
-	icon_state = "grey_railing0";
-	dir = 8
+	dir = 8;
+	icon_state = "grey_railing0"
 	},
 /obj/structure/railing/grey{
-	icon_state = "grey_railing0";
-	dir = 1
+	dir = 1;
+	icon_state = "grey_railing0"
 	},
 /turf/simulated/open,
 /area/eris/crew_quarters/bar)
@@ -92904,8 +92897,8 @@
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/weapon/tool/wirecutters,
 /obj/item/weapon/plantspray/pests,
@@ -92941,9 +92934,9 @@
 /area/eris/crew_quarters/pubeva)
 "dZG" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
@@ -92988,9 +92981,9 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section3)
 "dZO" = (
@@ -93003,16 +92996,16 @@
 "dZP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -93044,14 +93037,14 @@
 /area/eris/maintenance/section3deck2port)
 "dZS" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/neotheology/chapel)
@@ -93229,14 +93222,14 @@
 /area/eris/maintenance/section3deck2port)
 "eal" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 16;
@@ -93308,8 +93301,8 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
@@ -93544,9 +93537,9 @@
 /area/eris/medical/genetics)
 "eaV" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/medical/genetics)
@@ -93588,18 +93581,18 @@
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/syringes,
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (EAST)";
+	dir = 4;
 	icon_state = "danger";
-	dir = 4
+	tag = "icon-danger (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/xenobiology/xenoflora)
 "ebf" = (
 /obj/machinery/botany/editor,
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (WEST)";
+	dir = 8;
 	icon_state = "danger";
-	dir = 8
+	tag = "icon-danger (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/xenobiology/xenoflora)
@@ -93657,23 +93650,23 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section4)
 "ebl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section4)
 "ebm" = (
@@ -93705,9 +93698,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section4)
 "ebr" = (
@@ -93719,16 +93712,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/monofloor{
-	tag = "icon-monofloor (EAST)";
+	dir = 4;
 	icon_state = "monofloor";
-	dir = 4
+	tag = "icon-monofloor (EAST)"
 	},
 /area/eris/hallway/main/section4)
 "ebs" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/open,
@@ -93842,22 +93835,22 @@
 /obj/item/device/lighting/toggleable/lamp,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/industrial/danger/corner{
-	tag = "icon-dangercorner (EAST)";
+	dir = 4;
 	icon_state = "dangercorner";
-	dir = 4
+	tag = "icon-dangercorner (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/xenobiology/xenoflora)
 "ebI" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (NORTH)";
+	dir = 1;
 	icon_state = "danger";
-	dir = 1
+	tag = "icon-danger (NORTH)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/xenobiology/xenoflora)
@@ -93876,9 +93869,9 @@
 "ebK" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (NORTH)";
+	dir = 1;
 	icon_state = "danger";
-	dir = 1
+	tag = "icon-danger (NORTH)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/xenobiology/xenoflora)
@@ -93961,9 +93954,9 @@
 /area/eris/neotheology/office)
 "ebX" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (EAST)";
+	dir = 4;
 	icon_state = "up";
-	dir = 4
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
@@ -94040,9 +94033,9 @@
 	name = "Isolation to Waste"
 	},
 /obj/effect/floor_decal/industrial/danger/corner{
-	tag = "icon-dangercorner (WEST)";
+	dir = 8;
 	icon_state = "dangercorner";
-	dir = 8
+	tag = "icon-dangercorner (WEST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/xenobiology/xenoflora)
@@ -94248,9 +94241,9 @@
 "ecL" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/medical/genetics)
@@ -94275,9 +94268,9 @@
 /area/eris/maintenance/section3deck2port)
 "ecP" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2port)
@@ -94297,9 +94290,9 @@
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
@@ -94392,9 +94385,9 @@
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/effect/floor_decal/industrial/danger{
-	tag = "icon-danger (EAST)";
+	dir = 4;
 	icon_state = "danger";
-	dir = 4
+	tag = "icon-danger (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/xenobiology/xenoflora)
@@ -94436,8 +94429,8 @@
 /area/eris/quartermaster/misc)
 "edd" = (
 /obj/structure/sign/biohazard{
-	tag = "icon-bio-danger";
-	icon_state = "bio-danger"
+	icon_state = "bio-danger";
+	tag = "icon-bio-danger"
 	},
 /turf/simulated/wall/r_wall,
 /area/eris/rnd/xenobiology)
@@ -94462,15 +94455,15 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
@@ -94538,9 +94531,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/danger/corner{
-	tag = "icon-dangercorner (WEST)";
+	dir = 8;
 	icon_state = "dangercorner";
-	dir = 8
+	tag = "icon-dangercorner (WEST)"
 	},
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/tiled/white,
@@ -94550,9 +94543,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/tiled/white,
@@ -94629,14 +94622,14 @@
 /area/eris/maintenance/section3deck2port)
 "edy" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/disposalpipe/up{
-	tag = "icon-pipe-u (WEST)";
+	dir = 8;
 	icon_state = "pipe-u";
-	dir = 8
+	tag = "icon-pipe-u (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2port)
@@ -94720,9 +94713,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/tiled/white,
@@ -94846,9 +94839,9 @@
 /area/eris/quartermaster/misc)
 "edY" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/misc)
@@ -94908,9 +94901,9 @@
 /area/shuttle/research/station)
 "eej" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/space,
 /area/space)
@@ -94925,10 +94918,10 @@
 /area/eris/storage/primary)
 "eel" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/misc)
@@ -95012,9 +95005,9 @@
 /area/eris/maintenance/oldbridge)
 "eev" = (
 /obj/structure/bed/chair/comfy/purp{
-	tag = "icon-comfychair_preview (WEST)";
+	dir = 8;
 	icon_state = "comfychair_preview";
-	dir = 8
+	tag = "icon-comfychair_preview (WEST)"
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/eris/quartermaster/misc)
@@ -95327,8 +95320,8 @@
 /area/eris/maintenance/oldbridge)
 "efm" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -95420,9 +95413,9 @@
 /area/eris/engineering/propulsion/right)
 "efu" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/oldbridge)
@@ -95496,19 +95489,19 @@
 "efC" = (
 /obj/structure/lattice,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/misc)
 "efD" = (
 /obj/structure/lattice,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/misc)
@@ -95643,9 +95636,9 @@
 "efT" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/misc)
@@ -95659,10 +95652,10 @@
 "efV" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/misc)
@@ -95724,10 +95717,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
@@ -95896,49 +95889,49 @@
 /area/eris/medical/chemstor)
 "egt" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/misc)
 "egu" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/eris/quartermaster/misc)
 "egv" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/misc)
 "egw" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/misc)
@@ -96023,9 +96016,9 @@
 /area/eris/maintenance/section3deck2port)
 "egJ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -96039,9 +96032,9 @@
 /area/eris/maintenance/section4deck2starboard)
 "egL" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -96076,9 +96069,9 @@
 /area/eris/medical/chemstor)
 "egR" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck2port)
@@ -96105,10 +96098,10 @@
 /area/eris/rnd/anomalisolthree)
 "egU" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -96226,10 +96219,10 @@
 "ehj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /obj/structure/cable/green{
@@ -96467,8 +96460,8 @@
 /area/eris/maintenance/section4deck1central)
 "ehM" = (
 /obj/item/remains/robot{
-	tag = "icon-gib6";
-	icon_state = "gib6"
+	icon_state = "gib6";
+	tag = "icon-gib6"
 	},
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/plating,
@@ -96558,9 +96551,9 @@
 /area/eris/maintenance/section4deck1central)
 "eia" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
@@ -96610,9 +96603,9 @@
 /area/eris/maintenance/section4deck1central)
 "eih" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (NORTH)";
+	dir = 1;
 	icon_state = "pipe-j1";
-	dir = 1
+	tag = "icon-pipe-j1 (NORTH)"
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -96892,10 +96885,10 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck1central)
@@ -97037,10 +97030,10 @@
 "ejd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -97051,9 +97044,9 @@
 /area/eris/maintenance/section4deck1central)
 "eje" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -97067,10 +97060,10 @@
 	icon_state = "2-4"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -97419,16 +97412,16 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -97453,10 +97446,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -97474,8 +97467,8 @@
 /area/eris/maintenance/section4deck1central)
 "ejN" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-y";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-y"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -97513,10 +97506,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -97775,24 +97768,24 @@
 /area/eris/maintenance/section4deck1central)
 "ekt" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck1central)
 "eku" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck1central)
@@ -97992,10 +97985,10 @@
 "ekS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -98034,9 +98027,9 @@
 /area/eris/maintenance/section4deck1central)
 "ekY" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck1central)
@@ -98085,10 +98078,10 @@
 	sortType = list("Engineering")
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -98223,10 +98216,10 @@
 /area/eris/engineering/propulsion/left)
 "elB" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/medical/medbay/uppercor)
@@ -98321,10 +98314,10 @@
 "elO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -98351,10 +98344,10 @@
 /area/eris/maintenance/section4deck1central)
 "elR" = (
 /obj/structure/computerframe{
-	tag = "icon-0 (WEST)";
-	icon_state = "0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "0";
+	tag = "icon-0 (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck1central)
@@ -98478,9 +98471,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck1central)
@@ -98593,9 +98586,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck1central)
@@ -98610,17 +98603,17 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck1central)
 "emF" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -98656,10 +98649,10 @@
 	pixel_y = 32
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck1central)
@@ -98706,10 +98699,10 @@
 	pixel_y = -32
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck1central)
@@ -98750,8 +98743,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-j1"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -98793,9 +98786,9 @@
 /area/eris/quartermaster/misc)
 "enb" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section4deck1central)
@@ -98887,6 +98880,7 @@
 /area/shuttle/research/station)
 "enp" = (
 /obj/machinery/power/smes/buildable{
+	RCon_tag = "Hulk Mining Barge";
 	charge = 1.5e+007;
 	cur_coils = 3;
 	input_attempt = 1;
@@ -98894,12 +98888,11 @@
 	input_level_max = 750000;
 	output_attempt = 1;
 	output_level = 750000;
-	output_level_max = 750000;
-	RCon_tag = "Hulk Mining Barge"
+	output_level_max = 750000
 	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor,
 /area/shuttle/research/station)
@@ -99022,9 +99015,9 @@
 /area/eris/maintenance/section2deck1port)
 "enH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /obj/structure/lattice,
 /turf/space,
@@ -99213,8 +99206,8 @@
 /area/shuttle/research/station)
 "eoc" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
-	dir = 1
+	dir = 1;
+	icon_state = "term"
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -99642,41 +99635,41 @@
 /area/eris/quartermaster/misc)
 "epg" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/quartermaster/misc)
 "eph" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/open,
 /area/eris/maintenance/section3deck2starboard)
 "epi" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck2starboard)
 "epj" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck2starboard)
@@ -99852,9 +99845,9 @@
 /area/eris/rnd/xenobiology/xenoflora)
 "epG" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (WEST)";
+	dir = 8;
 	icon_state = "up";
-	dir = 8
+	tag = "icon-up (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 16;
@@ -100115,8 +100108,8 @@
 /area/shuttle/research/station)
 "equ" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section3)
@@ -100424,9 +100417,9 @@
 /area/eris/maintenance/section3deck2starboard)
 "eqX" = (
 /obj/machinery/atmospherics/pipe/zpipe/up{
-	tag = "icon-up (NORTH)";
+	dir = 1;
 	icon_state = "up";
-	dir = 1
+	tag = "icon-up (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 16;
@@ -100541,9 +100534,9 @@
 "erk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
@@ -100564,8 +100557,8 @@
 	pixel_x = -32
 	},
 /obj/structure/sink{
-	icon_state = "sink";
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -100636,9 +100629,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/down{
-	tag = "icon-pipe-d (EAST)";
+	dir = 4;
 	icon_state = "pipe-d";
-	dir = 4
+	tag = "icon-pipe-d (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -100649,9 +100642,9 @@
 /area/eris/maintenance/section3deck1central)
 "erv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -100705,10 +100698,10 @@
 "erB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -100793,9 +100786,9 @@
 	dir = 5
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -101015,8 +101008,8 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
-	dir = 2
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -101076,10 +101069,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -101095,8 +101088,8 @@
 "esm" = (
 /obj/structure/multiz/stairs/enter/bottom,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/storage)
@@ -101237,9 +101230,9 @@
 /area/eris/maintenance/section3deck1central)
 "esB" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (NORTH)";
+	dir = 1;
 	icon_state = "down";
-	dir = 1
+	tag = "icon-down (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -101270,8 +101263,8 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/storage)
@@ -101520,8 +101513,8 @@
 "eti" = (
 /obj/structure/table/bar_special,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
@@ -101534,8 +101527,8 @@
 	dir = 5
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/section3starboard)
@@ -101575,8 +101568,8 @@
 "etp" = (
 /obj/structure/multiz/stairs/enter,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/storage)
@@ -101596,8 +101589,8 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/section3starboard)
@@ -101712,8 +101705,8 @@
 "etE" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/pubeva)
@@ -101741,8 +101734,8 @@
 	req_one_access = list(13,48)
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/quartermaster/miningdock)
@@ -101818,9 +101811,9 @@
 "etO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -101831,8 +101824,8 @@
 /area/eris/maintenance/section3deck1central)
 "etP" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/misc)
@@ -101875,9 +101868,9 @@
 /area/eris/hallway/side/section3port)
 "etU" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -101886,10 +101879,10 @@
 /area/eris/quartermaster/misc)
 "etV" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -101912,9 +101905,9 @@
 "etX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -101944,8 +101937,8 @@
 "eua" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/weapon/storage/freezer/contains_food,
 /turf/simulated/floor/carpet/oracarpet,
@@ -101994,8 +101987,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/quartermaster/office)
@@ -102040,8 +102033,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/quartermaster/misc)
@@ -102078,17 +102071,17 @@
 "eum" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/quartermaster/office)
 "eun" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -102097,10 +102090,10 @@
 /area/eris/quartermaster/misc)
 "euo" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/light/small{
 	dir = 4;
@@ -102124,8 +102117,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/crew_quarters/fitness)
@@ -102337,8 +102330,8 @@
 /area/eris/quartermaster/storage)
 "euT" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/storage)
@@ -102357,8 +102350,8 @@
 /obj/structure/table/standard,
 /obj/machinery/electrolyzer,
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-y";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/medical/chemistry)
@@ -102472,9 +102465,9 @@
 /area/eris/neotheology/chapel)
 "evl" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair";
-	dir = 8
+	tag = "icon-wooden_chair (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -102529,10 +102522,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck3starboard)
@@ -102545,10 +102538,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck3starboard)
@@ -102563,10 +102556,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck3starboard)
@@ -102663,10 +102656,10 @@
 /area/eris/hallway/side/section3starboard)
 "evB" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck3starboard)
@@ -102712,10 +102705,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck3starboard)
@@ -102726,9 +102719,9 @@
 "evH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck3starboard)
@@ -102758,16 +102751,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck3starboard)
@@ -102776,10 +102769,10 @@
 	dir = 6
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck3starboard)
@@ -102788,9 +102781,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck3starboard)
@@ -102899,10 +102892,10 @@
 "evY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck3starboard)
@@ -102949,9 +102942,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -102963,8 +102956,8 @@
 "ewe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/section3starboard)
@@ -103011,8 +103004,8 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/section3starboard)
@@ -103253,9 +103246,9 @@
 /area/eris/quartermaster/storage)
 "ewK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/propulsion/left)
@@ -103294,10 +103287,10 @@
 "ewO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -103388,8 +103381,8 @@
 "ewY" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 28
@@ -103530,9 +103523,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
@@ -103548,9 +103541,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
@@ -103579,9 +103572,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /obj/structure/cable/green{
@@ -104011,15 +104004,15 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -104181,9 +104174,9 @@
 "eyF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
@@ -104193,10 +104186,10 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
@@ -104232,10 +104225,10 @@
 /area/eris/maintenance/section3deck2starboard)
 "eyK" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/hallway/side/atmosphericshallway)
@@ -104255,9 +104248,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
@@ -104267,10 +104260,10 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
@@ -104330,30 +104323,30 @@
 /area/eris/engineering/breakroom)
 "eyZ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
 "eza" = (
 /obj/random/junk/low_chance,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
 "ezb" = (
 /obj/random/scrap/dense_weighted,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
@@ -104402,10 +104395,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -104431,10 +104424,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -104487,10 +104480,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -104539,25 +104532,25 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "ezu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -104566,10 +104559,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -104578,16 +104571,16 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -104596,18 +104589,18 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "ezy" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/propulsion/left)
@@ -104616,9 +104609,9 @@
 	dir = 6
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -104633,15 +104626,15 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -104658,16 +104651,16 @@
 	sortType = list("Library Backroom")
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -104682,10 +104675,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -104693,10 +104686,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -104745,9 +104738,9 @@
 "ezK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -104761,10 +104754,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -104788,18 +104781,18 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "ezQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -104920,9 +104913,9 @@
 	icon_state = "2-8"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -104937,26 +104930,26 @@
 	sortType = list("Theatre")
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "eAd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -104984,9 +104977,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -105012,10 +105005,10 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -105028,10 +105021,10 @@
 	icon_state = "pipe-y"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -105109,10 +105102,10 @@
 	dir = 5
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -105160,9 +105153,9 @@
 /area/eris/engineering/propulsion/left)
 "eAy" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/propulsion/left)
@@ -105180,16 +105173,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -105273,10 +105266,10 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -105315,9 +105308,9 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -105372,10 +105365,10 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -105412,9 +105405,9 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -105474,10 +105467,10 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -105523,9 +105516,9 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -105575,9 +105568,9 @@
 /area/eris/neotheology/bioreactor)
 "eBm" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-y (EAST)";
+	dir = 4;
 	icon_state = "pipe-y";
-	dir = 4
+	tag = "icon-pipe-y (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -105669,9 +105662,9 @@
 /area/eris/engineering/propulsion/left)
 "eBu" = (
 /obj/structure/bed/chair/wood{
-	tag = "icon-wooden_chair (WEST)";
+	dir = 8;
 	icon_state = "wooden_chair";
-	dir = 8
+	tag = "icon-wooden_chair (WEST)"
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "maint_hatch_church_north";
@@ -105906,9 +105899,9 @@
 /area/eris/engineering/starboardhallway)
 "eBS" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
@@ -105941,10 +105934,10 @@
 /area/eris/hallway/main/section2)
 "eBX" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
@@ -106142,36 +106135,36 @@
 /area/eris/engineering/gravity_generator)
 "eCs" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
 "eCt" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
 "eCu" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
@@ -106356,9 +106349,9 @@
 /area/eris/engineering/gravity_generator)
 "eCR" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
@@ -106367,10 +106360,10 @@
 /area/eris/engineering/gravity_generator)
 "eCT" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
@@ -106664,9 +106657,9 @@
 "eDE" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
+	dir = 4;
 	icon_state = "railing0";
-	dir = 4
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1port)
@@ -106882,18 +106875,18 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
 "eEg" = (
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
+	dir = 8;
 	icon_state = "pipe-j1";
-	dir = 8
+	tag = "icon-pipe-j1 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -106929,9 +106922,9 @@
 "eEj" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
@@ -106942,10 +106935,10 @@
 "eEl" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
@@ -106976,24 +106969,24 @@
 /area/eris/maintenance/section1deck1central)
 "eEp" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "eEq" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 4;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -107005,9 +106998,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
@@ -107021,41 +107014,41 @@
 /area/eris/engineering/engine_room)
 "eEu" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "eEv" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "eEw" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "eEx" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
+	dir = 8;
 	icon_state = "railing0";
-	dir = 8
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -107171,9 +107164,9 @@
 /area/eris/engineering/gravity_generator)
 "eEL" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -107184,9 +107177,9 @@
 /area/eris/maintenance/section3deck1central)
 "eEM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -107197,9 +107190,9 @@
 /area/eris/maintenance/section3deck1central)
 "eEN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -107228,10 +107221,10 @@
 /area/eris/engineering/breakroom)
 "eEQ" = (
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -107239,10 +107232,10 @@
 "eER" = (
 /obj/structure/lattice,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
@@ -107710,15 +107703,15 @@
 /area/eris/command/exultant)
 "eFJ" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
 /area/eris/engineering/starboardhallway)
@@ -107737,9 +107730,9 @@
 /area/eris/engineering/gravity_generator)
 "eFO" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -107753,15 +107746,15 @@
 /area/eris/engineering/propulsion/left)
 "eFW" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	tag = "icon-down (WEST)";
+	dir = 8;
 	icon_state = "down";
-	dir = 8
+	tag = "icon-down (WEST)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 8;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 32;
@@ -107776,9 +107769,9 @@
 "eFZ" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -107905,9 +107898,9 @@
 /area/eris/engineering/propulsion/right)
 "eHL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/propulsion/right)
@@ -108061,9 +108054,9 @@
 /area/eris/engineering/propulsion/right)
 "eKU" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (NORTH)";
+	dir = 1;
 	icon_state = "map";
-	dir = 1
+	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/propulsion/right)
@@ -108099,9 +108092,9 @@
 /area/shuttle/mining/station)
 "eLM" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	tag = "icon-intact (NORTH)";
+	dir = 1;
 	icon_state = "intact";
-	dir = 1
+	tag = "icon-intact (NORTH)"
 	},
 /obj/structure/lattice,
 /turf/space,
@@ -108113,18 +108106,18 @@
 /area/space)
 "eLO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (NORTHEAST)";
+	dir = 5;
 	icon_state = "intact";
-	dir = 5
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/lattice,
 /turf/space,
 /area/space)
 "eLP" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /turf/simulated/floor/hull,
 /area/space)
@@ -108142,9 +108135,9 @@
 /area/space)
 "eLS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (NORTHWEST)";
+	dir = 9;
 	icon_state = "intact";
-	dir = 9
+	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/hull{
 	flooring_override = "hullcenter18";
@@ -108251,9 +108244,9 @@
 /area/eris/medical/surgery)
 "fzU" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	tag = "icon-map (EAST)";
+	dir = 4;
 	icon_state = "map";
-	dir = 4
+	tag = "icon-map (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -108345,8 +108338,8 @@
 /area/eris/medical/surgery)
 "hqB" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	icon_state = "intact";
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/hull,
 /area/space)
@@ -108391,10 +108384,10 @@
 "ikb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
-	icon_state = "railing0";
+	anchored = 1;
 	dir = 1;
-	anchored = 1
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -108725,8 +108718,8 @@
 /area/eris/medical/surgery)
 "msv" = (
 /obj/machinery/atmospherics/unary/heat_exchanger{
-	icon_state = "intact";
-	dir = 1
+	dir = 1;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/eris/engineering/engine_room)
@@ -108865,9 +108858,9 @@
 "nuu" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	tag = "icon-intact (SOUTHEAST)";
+	dir = 6;
 	icon_state = "intact";
-	dir = 6
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/space,
 /area/space)
@@ -108970,9 +108963,9 @@
 /area/eris/medical/chemistry)
 "oAW" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/hull,
 /area/space)
@@ -108994,9 +108987,9 @@
 /area/eris/medical/medbay/uppercor)
 "oHW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -109038,8 +109031,8 @@
 	pixel_y = -32
 	},
 /obj/machinery/computer/aifixer{
-	icon_state = "computer";
-	dir = 1
+	dir = 1;
+	icon_state = "computer"
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/eris/command/meo)
@@ -109050,8 +109043,8 @@
 /area/eris/engineering/engine_room)
 "ppk" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/surgery)
@@ -109238,9 +109231,9 @@
 /area/eris/security/warden)
 "tdm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (EAST)";
+	dir = 4;
 	icon_state = "intact";
-	dir = 4
+	tag = "icon-intact (EAST)"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -109309,9 +109302,9 @@
 /area/eris/medical/chemistry)
 "uiz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	tag = "icon-intact (SOUTHWEST)";
+	dir = 10;
 	icon_state = "intact";
-	dir = 10
+	tag = "icon-intact (SOUTHWEST)"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -109331,9 +109324,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (NORTH)";
+	dir = 1;
 	icon_state = "railing0";
-	dir = 1
+	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
@@ -109357,8 +109350,8 @@
 	dir = 6
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/atmos)
@@ -109421,8 +109414,8 @@
 /area/space)
 "vpg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
-	icon_state = "intact";
-	dir = 5
+	dir = 5;
+	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/engine_room)
@@ -109470,8 +109463,8 @@
 "wjY" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/generator/anchored{
-	icon_state = "teg-assembled";
-	dir = 4
+	dir = 4;
+	icon_state = "teg-assembled"
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -244001,10 +243994,10 @@ abF
 abF
 abF
 abF
-aaa
-aaa
-aaa
-aaa
+abF
+abF
+abF
+abF
 aaa
 aaa
 aaa
@@ -244203,10 +244196,10 @@ abF
 abF
 abF
 abF
-aaa
-aaa
-aaa
-aaa
+abF
+abF
+abF
+abF
 abF
 abF
 abF
@@ -244405,9 +244398,9 @@ abF
 abF
 abF
 abF
-aaa
-aaa
-aaa
+abF
+abF
+abF
 abF
 abF
 abF
@@ -244607,8 +244600,8 @@ abF
 abF
 abF
 abF
-aaa
-aaa
+abF
+abF
 bdL
 bdL
 bdL
@@ -244809,8 +244802,8 @@ abF
 abF
 abF
 abF
-aaa
-aaa
+abF
+abF
 bdL
 bdM
 bdL
@@ -245011,8 +245004,8 @@ bYo
 bYo
 abF
 abF
-aaa
-aaa
+abF
+abF
 bdL
 bgd
 cIv
@@ -245213,7 +245206,7 @@ dhm
 bYo
 abF
 abF
-aaa
+abF
 bdL
 bdL
 bgd


### PR DESCRIPTION
## About The Pull Request

There are a leak to the space that causes minor inconvenience to the finest of all medical professionals hired on NanoTrash vessel Northern Lights.

## Why It's Good For The Game

Quality assurance that makes sure that our finest doctors doesn't get spaced out when they walk into the cloning room. Those doctors don't grow on trees, y'know.

## Changelog
```changelog
fix: Patched a leak to the space in the Medical cloning room
```