### PR TITLE
Bandaid Patch for Spawning Without A Cruciform

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -430,8 +430,9 @@
 		new_character.create_soulcrypt()
 
 	//REEEEE GIMME A CRUCIFORM	-	Syzygy edit
-	if(new_character.client.prefs.get_option("Core implant"))	//checks if you have the cruciform selected in the augments menu of the character creator
-		var/obj/item/weapon/implant/core_implant/C = new /obj/item/weapon/implant/core_implant/cruciform(new_character) //spawns the cruciform inside you
+	var/datum/category_item/setup_option/core_implant/I = new_character.client.prefs.get_option("Core implant")	// gets the core implant selected in the character creator, which can either be the cruciform, or nothing.
+	if(I.implant_type)	//Checks if an implant is selected. If there is none selected, do nothing.
+		var/obj/item/weapon/implant/core_implant/C = new I.implant_type	//spawns the implant
 		C.install(new_character) //installs it inside you
 		C.activate() //turns it on
 		C.install_default_modules_by_job(new_character.mind.assigned_job)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -429,6 +429,15 @@
 	if(new_character.client && new_character.client.prefs.has_soulcrypt)
 		new_character.create_soulcrypt()
 
+	//REEEEE GIMME A CRUCIFORM	-	Syzygy edit
+	if(new_character.client.prefs.get_option("Core implant"))	//checks if you have the cruciform selected in the augments menu of the character creator
+		var/obj/item/weapon/implant/core_implant/C = new /obj/item/weapon/implant/core_implant/cruciform(new_character) //spawns the cruciform inside you
+		C.install(new_character) //installs it inside you
+		C.activate() //turns it on
+		C.install_default_modules_by_job(new_character.mind.assigned_job)
+		C.access.Add(new_character.mind.assigned_job.cruciform_access)
+	//Best to fix the missing cruciform issue instead of relying on this crutch
+
 	return new_character
 
 /mob/new_player/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, var/glide_size_override = 0)


### PR DESCRIPTION
## About The Pull Request

This is NOT a fix for characters not spawning with a Cruciform. This is simply a literal bandaid that checks if a character has it selected in the character creator, then forcibly installs a cruciform on-spawn. It can be an effective stop-gap measure while we try and figure out how to actually fix the underlying problem.

## Changelog
```changelog Toriate
fix: Bandaid patch to make characters spawn (im)properly with Cruciforms
```
