### PR TITLE
Fixes Traitor Uplink Exploitable Information

### DIFF
--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -82,9 +82,21 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
         <div class="item">
             <div class="itemContent" style="width: 100%;">
                 {{if data.exploit_exists == 1}}
-					{{for data.exploit.fields}}
-                  	  <span class="good">{{:value.name}}:		</span> <span class="average">{{:value.value}}</span><br>
-					{{/for}}
+					<span class="good">Name:				</span> <span class="average">{{:data.exploit.name}}			</span><br>
+                    <span class="good">Sex:					</span> <span class="average">{{:data.exploit.sex}}				</span><br>
+                    <span class="good">Species:				</span> <span class="average">{{:data.exploit.species}}			</span><br>
+                    <span class="good">Age:					</span> <span class="average">{{:data.exploit.age}}				</span><br>
+                    <span class="good">Rank:				</span> <span class="average">{{:data.exploit.rank}}			</span><br>
+                    <span class="good">Fingerprint:			</span> <span class="average">{{:data.exploit.fingerprint}}		</span><br>
+
+                    <br>Acquired Information:<br>
+                    <span class="good">Notes:<br>	</span> <span class="average">{{:data.exploit.nanoui_exploit_record}}</span><br><br>
+                {{else}}
+					<span class="bad">
+                        No exploitative information acquired!
+						<br>
+                        <br>
+                    </span>
                 {{/if}}
             </div>
         </div>


### PR DESCRIPTION
## About The Pull Request

As it turns out, it wasn't the character creator not saving exploitable information, it was the Uplink interface completely failing to display the information itself! With some HTML fuckery, it is now fixed. Closes #58 

![2EBBud0U5u](https://user-images.githubusercontent.com/31995558/92251664-be008e00-eeff-11ea-9f7e-76ac50c88070.png)

## Changelog
```changelog Toriate
fix: Traitor Uplinks should now display Exploitable Information properly, instead of leaving a blank space.
```