### PR TITLE
Fix null-related runtimes

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -511,7 +511,8 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 	for(var/A in hud_actions)
 		var/obj/item/action = A
-		action.update_icon()
+		if(action)
+			action.update_icon()
 
 /obj/item/proc/refresh_upgrades()
 	return

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -504,8 +504,9 @@ var/global/list/default_medbay_channels = list(
 	// check if this radio can receive on the given frequency, and if so,
 	// what the range is in which mobs will hear the radio
 	// returns: -1 if can't receive, range otherwise
-
-	if (wires.IsIndexCut(WIRE_RECEIVE))
+	if (QDELING(src))
+		return -1
+	if (wires?.IsIndexCut(WIRE_RECEIVE))
 		return -1
 	if(!listening)
 		return -1

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -163,7 +163,7 @@ var/list/flooring_cache = list()
 		else if (istype(T, /turf/simulated/floor))
 			var/turf/simulated/floor/t = T
 			//If the floor is the same as us,then we're linked,
-			if (t.flooring.type == type)
+			if (t.flooring && t.flooring.type == type)
 				is_linked = TRUE
 				/*
 					But there's a caveat. To make atom black/whitelists work correctly, we also need to check that

--- a/code/modules/modular_computers/hardware/scanners/scanner_reagent.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner_reagent.dm
@@ -17,6 +17,6 @@
 	var/dat = reagent_scan_results(target)
 	if(driver && driver.using_scanner)
 		driver.data_buffer = dat
-		if(!SSnano.update_uis(driver.NM))
+		if(driver.NM && !SSnano.update_uis(driver.NM))
 			holder2.run_program(driver.filename)
-			driver.NM.ui_interact(user)
+			driver.NM?.ui_interact(user)


### PR DESCRIPTION
## About The Pull Request

Attempt to fix some runtimes that are caused by null values

## Why It's Good For The Game

Makes the game more sane, and the runtime log more clean

- Fixes https://github.com/SyzygyStation/Syzygy-Eris/issues/57
- Fixes https://github.com/SyzygyStation/Syzygy-Eris/issues/78
- Fixes https://github.com/SyzygyStation/Syzygy-Eris/issues/88
- Fixes https://github.com/SyzygyStation/Syzygy-Eris/issues/89

## Changelog
```changelog
fix: Fix a runtime related to updating icons of HUD-actions 
fix: Fix a runtime related to turf floorings when using the Holodeck
fix. Fix a runtime related to radios
fix: Fix a runtime related to reagent scanner module for hardsuits
```
