### PR TITLE
Soulcrypt hold stats & remove harpoons from traitors and loot pools.

### DIFF
--- a/code/datums/contract.dm
+++ b/code/datums/contract.dm
@@ -38,7 +38,6 @@ GLOBAL_LIST_INIT(excel_item_targets,list(
 		"a cruciform" = /obj/item/weapon/implant/core_implant/cruciform,
 		"the station blueprints" = /obj/item/blueprints,
 		"a hand teleporter" = /obj/item/weapon/hand_tele,
-		"a bluespace Harpoon" = /obj/item/weapon/bluespace_harpoon,
 		"a rocket-powered charge hammer" = /obj/item/weapon/tool/hammer/charge,
 		"the captain's antique laser gun" = /obj/item/weapon/gun/energy/captain,
 

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -316,7 +316,7 @@
 	name = "Blitzshell Blue Space Harpoon"
 	desc = "Activates the embedded bluespace harpoon."
 	item_cost = 12
-	antag_roles = list(ROLE_BLITZ)
+	antag_roles = list() // list(ROLE_BLITZ) -- Syzygy edit to disable biltz getting BS harps
 
 /datum/uplink_item/item/tools/blitz_harpoon/get_goods(var/obj/item/device/uplink/U, var/loc, var/mob/living/user)
 	if(user && istype(user, /mob/living/silicon/robot/drone/blitzshell))

--- a/code/modules/core_implant/cruciform/machinery/cloning.dm
+++ b/code/modules/core_implant/cruciform/machinery/cloning.dm
@@ -243,6 +243,7 @@
 			occupant.UpdateAppearance()
 			occupant.sync_organ_dna()
 			occupant.flavor_text = R.host_flavor_text
+			occupant.stats = R.host_stats // Syzygy edit to copy stats from old mob to other
 			// occupant.stats = R.stats // commented out because it's a variable used by the cruciform, uncomment when we're back to using cruciforms
 
 		if(progress == CLONING_BODY || progress <= CLONING_BODY && progress > CLONING_BODY-10)

--- a/code/modules/soulcrypt/base_implant.dm
+++ b/code/modules/soulcrypt/base_implant.dm
@@ -28,10 +28,11 @@ The module base code is held in module.dm
 
 	var/nutrition_usage_setting = NUTRITION_USAGE_LOW //These can be found in soulcrypt.dm, under DEFINES.
 
-	var/stat//Status.
+	var/stat/Status
 	//Host variables, stored for cloning.
 	var/datum/dna/host_dna
 	var/datum/mind/host_mind
+	var/datum/stat_holder/host_stats
 	var/host_age
 	var/host_flavor_text
 	var/list/host_languages = list()
@@ -83,6 +84,7 @@ The module base code is held in module.dm
 		host_mind = wearer.mind
 		host_dna = wearer.dna.Clone()
 		host_age = wearer.age
+		host_stats = wearer.stats
 		host_flavor_text = wearer.flavor_text
 		has_stored_info = TRUE
 		host_name = wearer.dna.real_name

--- a/code/modules/soulcrypt/base_implant.dm
+++ b/code/modules/soulcrypt/base_implant.dm
@@ -28,7 +28,7 @@ The module base code is held in module.dm
 
 	var/nutrition_usage_setting = NUTRITION_USAGE_LOW //These can be found in soulcrypt.dm, under DEFINES.
 
-	var/stat/Status
+	var/stat // Status
 	//Host variables, stored for cloning.
 	var/datum/dna/host_dna
 	var/datum/mind/host_mind

--- a/code/modules/stashes/stash_types/captain.dm
+++ b/code/modules/stashes/stash_types/captain.dm
@@ -26,7 +26,6 @@
 	/obj/item/weapon/stamp/captain = 35,
 	/obj/item/weapon/disk/nuclear = 15,
 	/obj/item/weapon/hand_tele = 25,
-	/obj/item/weapon/bluespace_harpoon = 15,
 	/obj/item/weapon/reagent_containers/hypospray = 15,
 	/obj/item/weapon/hatton = 15,
 	/obj/item/weapon/rcd = 15,


### PR DESCRIPTION
## About The Pull Request

A pretty salty PR.

## Why It's Good For The Game

Appeal to your emotions man. Salt Station 13 is the way of life.

## Changelog
```changelog
add: Stats are now stored in soulcrypts
add: Stats are transferred to new clones via the soulcrypt
del: Removed the bluespace harpoon from random loot
del: Removed the integrated bluespace harpoon from biltzshell drones
balance: Excelsior agents no longer have to find a bluespace harpoon
```
