### PR TITLE
Minor Hivemind Nerf

### DIFF
--- a/code/game/gamemodes/events/hivemind_invasion.dm
+++ b/code/game/gamemodes/events/hivemind_invasion.dm
@@ -36,4 +36,5 @@
 			break
 
 	message_admins("Hivemind spawned at \the [jumplink(start_location)]")
+	command_announcement.Announce("Confirmed outbreak of biomechanical infestation aboard [station_name()] in [get_area(start_location)]. All personnel must contain the outbreak.", "Anomaly Alert")	// syzygy edit - announce the room in which the hivemind core spawned
 	new /obj/machinery/hivemind_machine/node(start_location)

--- a/zzz_modular_syzygy/hugbox.dm
+++ b/zzz_modular_syzygy/hugbox.dm
@@ -23,3 +23,54 @@
 
 /obj/item/stack/material/biomatter/full
 	amount = 300
+
+///////////////////////////////// ANTAG SPECIFIC NERFS	//////////////////////////////////////////////////////////////////////////////
+
+// Hivemind Core nerf
+
+/datum/hivemind_sdp/shockwave
+	cooldown = 15 SECONDS	//3 times longer to actually let you escape
+
+// The following are the TRULY hugbox nerfs that were designed based on community feedback. Not to be uncommented without extensive discussion, testing and preferably voting.
+
+/*
+/datum/hivemind_sdp/shockwave/execute()		//fairly wonky override with no callback
+	master.visible_message("[master] emmits an energy wave!")
+	playsound(master, 'sound/effects/EMPulse.ogg', 90, 1)
+	var/list/targets = mobs_in_view(attack_range, master)
+	for(var/mob/living/victim in targets)
+		if(victim.stat == CONSCIOUS && victim.faction != HIVE_FACTION)
+			victim.Weaken(5)
+			step_away(victim, master)
+
+	set_cooldown()
+
+// Hivemind Turret nerf
+
+/obj/item/projectile/goo
+	damage_types = list(BURN = 5)	// the real risk is gonna come from the toxin damage rather than the burn
+
+// Hivemind Wire nerf
+
+/obj/effect/plant/hivemind
+	health = 		40
+	max_health = 	40	//half health so you can just unga chop it if your ROB isn't high enough to insta delete it
+
+/obj/structure/burrow/spread_plants()
+	return	// haha fuck your spreading kudzu and wires
+
+// Hivemind stun nerf
+
+/obj/machinery/hivemind_machine/screamer/use_ability(mob/living/target)
+
+	var/mob/living/carbon/human/H = target
+	if(istype(H))
+		if(prob(100 - H.stats.getStat(STAT_VIG)))
+			H.Weaken(2)
+			to_chat(H, SPAN_WARNING("A terrible howl tears through your mind, the voice senseless, soulless."))
+		else
+			to_chat(H, SPAN_NOTICE("A terrible howl tears through your mind, but you refuse to listen to it!"))
+	else
+		target.Weaken(2)
+		to_chat(target, SPAN_WARNING("A terrible howl tears through your mind, the voice senseless, soulless."))
+*/


### PR DESCRIPTION
## About The Pull Request

This PR will cause a Hivemind Core's presence and rough location to be revealed to the crew upon spawn, and also makes the Core less capable of stunlocking people.

Note that there are technically much more nerfs included in this PR, but they have been commented out. They are there only for reference on what the community has suggested so far.

## Changelog
```changelog Toriate
balance: Hivemind Core now has a longer cooldown between pulses, and their location will be revealed on spawn.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
