### PR TITLE
Make taurs show up properly in space suits

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1172,7 +1172,7 @@ var/global/list/damage_icon_parts = list()
 	var/standing = null
 
 	var/image/vr_tail_image = get_tail_image()
-	if(vr_tail_image && !(wear_suit && wear_suit.flags_inv & HIDETAIL))
+	if(vr_tail_image)
 		standing = vr_tail_image
 	else
 		var/species_tail = species.get_tail(src)


### PR DESCRIPTION
## About The Pull Request

Removed a redundant check in human update_icons that was interfering with a more comprehensive check in get_tail_icon that actually takes the presence of taur bits into account.

![dreamseeker_zWmDlFvYgi](https://user-images.githubusercontent.com/31995558/93016765-2cc3a280-f5f6-11ea-9685-fc24ff3fa4a5.png)  ![dreamseeker_Az3cpbqK04](https://user-images.githubusercontent.com/31995558/93016766-2d5c3900-f5f6-11ea-9c9e-a491093edd2c.png)

## Changelog
```changelog Toriate
fix: Taurs now show up properly in space suits
```