### PR TITLE
Maps a defib cabinet into the medical office

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -108520,6 +108520,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/construction)
+"gJE" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/defibcabinet{
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/eris/medical/reception)
 "gPD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -108573,13 +108580,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep/cryo)
-"hUQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/window_lwall_spawn/smartspawn,
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section3deck2starboard)
 "iaf" = (
 /obj/structure/multiz/stairs/enter{
 	dir = 1
@@ -210130,7 +210130,7 @@ bSx
 bSV
 chM
 cYV
-crD
+gJE
 cWj
 dgo
 dAL


### PR DESCRIPTION
## About The Pull Request

Quick stop-gap PR to map in a defib into medical so it doesn't have to be spawned in everytime.
![dreamseeker_kK5HgMoPDh](https://user-images.githubusercontent.com/31995558/93022657-02d1a680-f61d-11ea-95da-d3610c40dfed.png)

## Changelog
```changelog Toriate
add: Added a defib cabinet to the medical office
```
