### PR TITLE
adds the Mentor storyteller

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2713,4 +2713,5 @@
 #include "zzz_modular_syzygy\hugbox.dm"
 #include "zzz_modular_syzygy\loadout.dm"
 #include "zzz_modular_syzygy\projectiles.dm"
+#include "zzz_modular_syzygy\storytellers\mentor.dm"
 // END_INCLUDE

--- a/zzz_modular_syzygy/storytellers/mentor.dm
+++ b/zzz_modular_syzygy/storytellers/mentor.dm
@@ -1,0 +1,10 @@
+/datum/storyteller/mentor
+	config_tag = "mentor"
+	name = "The Mentor"
+	welcome = "Life will never be fair, but it need not always be terrible."
+	description = "A patient storyteller that spawns few events and fewer antagonists. Good for learning new things or just to relax."
+
+	gain_mult_mundane = 0.3
+	gain_mult_moderate = 0.2
+	gain_mult_major = 0.15
+	gain_mult_roleset = 0.1


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a storyteller to emulate a traditional round of Extended while still keeping everyone on their toes. It's even more passive than Sleeper; antag roles in particular are _ten times less likely_ to happen.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sometimes the crew just wants to sit down and roleplay for intervals longer than five minutes before the next vermintide shows up and kicks everyone in the ass. This lets that happen.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```
add: mentor storyteller
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
