### PR TITLE
[CHERRY PICK] Removes a mob spawner from one of the One Star dungeon rooms (#5424)

### DIFF
--- a/maps/submaps/dungeon_rooms/rooms/armory_secure.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/armory_secure.dmm
@@ -11,7 +11,7 @@
 /turf/simulated/floor/plating/under,
 /area/crawler)
 "d" = (
-/obj/machinery/porta_turret/stationary,
+/obj/machinery/porta_turret/One_star,
 /turf/simulated/floor/plating/under,
 /area/crawler)
 "e" = (
@@ -23,8 +23,8 @@
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "g" = (
-/obj/random/mob/roomba,
 /obj/random/contraband,
+/obj/random/mob/roomba,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)
 "h" = (


### PR DESCRIPTION
## About The Pull Request

Cherry pick of https://github.com/discordia-space/CEV-Eris/pull/5424

## Changelog
```changelog Eris Contributors
admin: fixed admin issue regarding log spam
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
