### PR TITLE
Oddity storage changes to make some easier to have on your person

### DIFF
--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -55,6 +55,7 @@
 	name = "strange coin"
 	desc = "It appears to be more of a collectible than any sort of actual currency. What metal it's made from seems to be a mystery."
 	icon_state = "coin"
+	w_class = ITEM_SIZE_TINY //Now you can fit them on your ear
 	oddity_stats = list(
 		STAT_ROB = 5,
 		STAT_TGH = 5,
@@ -151,6 +152,7 @@
 	name = "old money"
 	desc = "It's not like the organization that issued this exists anymore."
 	icon_state = "old_money"
+	w_class = ITEM_SIZE_TINY //So you cnan fit in on your ear slot too
 	oddity_stats = list(
 		STAT_ROB = 4,
 		STAT_TGH = 4,

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -465,6 +465,7 @@ BLIND     // can't see anything
 			/obj/item/weapon/tool/knife/butterfly,
 			/obj/item/weapon/material/kitchen/utensil,
 			/obj/item/weapon/tool/knife/tacknife,
+			/obj/item/weapon/oddity/common/old_knife //Syzygy change that should have been done forever ago
 		)
 	if(can_hold_knife && is_type_in_list(I, knifes))
 		if(holding)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Can fit old knives in your boots and old coins and cash on your ear slot to make them easier to carry around.

## Why It's Good For The Game
Because not all players carry around backpacks or have a lot of pockets as their job!

## Changelog
```changelog
tweak: made some oddities easier to carry
```