### PR TITLE
Makes the mime storyteller eligible for voting

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2716,4 +2716,5 @@
 #include "zzz_modular_syzygy\lockers.dm"
 #include "zzz_modular_syzygy\projectiles.dm"
 #include "zzz_modular_syzygy\storytellers\mentor.dm"
+#include "zzz_modular_syzygy\storytellers\overrides.dm"
 // END_INCLUDE

--- a/zzz_modular_syzygy/storytellers/overrides.dm
+++ b/zzz_modular_syzygy/storytellers/overrides.dm
@@ -1,0 +1,4 @@
+// Syzygy's storyteller overrides go here
+
+/datum/storyteller/mime		// Literally does nothing. Intended for running admin events and is not votable.
+	votable = TRUE	// H O N K


### PR DESCRIPTION
## About The Pull Request

The Mime storyteller is an admin-select-only storyteller that will literally do nothing. This PR will make it so that players can vote for it.

## Changelog
```changelog Toriate
tweak: Made The Mime storyteller votable
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
