### PR TITLE
Slight changes to Unathi

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -34,8 +34,8 @@
 	gluttonous = 1
 	slowdown = 0.5
 	total_health = 125
-	brute_mod = 0.85
-	burn_mod = 0.85
+	brute_mod = 0.90	//syzygy edit
+	burn_mod = 0.90		//also edit
 	color_mult = 1
 //	metabolic_rate = 0.85
 //	item_slowdown_mod = 0.25
@@ -85,7 +85,7 @@
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
 	flesh_color = "#34AF10"
-	blood_color = "#b3cbc3"
+	blood_color = "#f24b2e"		//syzygy edit
 	base_color = "#066000"
 
 //	reagent_tag = IS_UNATHI


### PR DESCRIPTION
## About The Pull Request

Unathi blood color was... not right, changed it to be in line with Bay. Also rebalanced stats slightly to be in line with the species stats document.

## Why It's Good For The Game

The changes to species stats were requested. This is done specifically for Unathi balance since they're kinda... really tanky.

## Changelog
```changelog
tweak: changed unathi blood color to normal bay orange
tweak: changed stats for unathi, specifically the resists
```

