### PR TITLE
Trap-style awareness for wire splicing.

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2718,5 +2718,6 @@
 #include "zzz_modular_syzygy\projectiles.dm"
 #include "zzz_modular_syzygy\roach.dm"
 #include "zzz_modular_syzygy\stashes.dm"
+#include "zzz_modular_syzygy\wire_splicing.dm"
 #include "zzz_modular_syzygy\storytellers\mentor.dm"
 // END_INCLUDE

--- a/code/game/objects/structures/wire_splicing.dm
+++ b/code/game/objects/structures/wire_splicing.dm
@@ -8,6 +8,7 @@
 	flags = CONDUCT
 	layer = TURF_LAYER + 0.45
 	var/messiness = 0 // How bad the splicing was, determines the chance of shock
+	var/list/aware_mobs = list() //List of refs of mobs that examined this trap. Won't trigger it when walking. //Syzygy Edit.
 
 /obj/structure/wire_splicing/Initialize(roundstart)
 	.=..()
@@ -75,12 +76,18 @@
 	..()
 	to_chat(user, "It has [messiness] wire[messiness > 1?"s":""] dangling around")
 
+	if(isliving(user) && !("\ref[user]" in aware_mobs))	//Syzygy Edit.
+		to_chat(user, SPAN_NOTICE("You're aware of this wire splicing, now. You won't clumsily step on it when walking carefully."))
+		aware_mobs |= "\ref[user]"
+
 /obj/structure/wire_splicing/Crossed(AM as mob|obj)
 	if(isliving(AM))
 		var/mob/living/L = AM
 		var/turf/T = get_turf(src)
 		var/chance_to_shock = messiness * 10
 		chance_to_shock -= L.skill_to_evade_traps(chance_to_shock)
+		if(("\ref[L]" in aware_mobs) && MOVING_DELIBERATELY(L))	//Syzygy Edit.
+			return ..()
 		if(locate(/obj/structure/catwalk) in T)
 			chance_to_shock -= 20
 		if(prob(chance_to_shock))

--- a/code/game/objects/structures/wire_splicing.dm
+++ b/code/game/objects/structures/wire_splicing.dm
@@ -8,7 +8,6 @@
 	flags = CONDUCT
 	layer = TURF_LAYER + 0.45
 	var/messiness = 0 // How bad the splicing was, determines the chance of shock
-	var/list/aware_mobs = list() //List of refs of mobs that examined this trap. Won't trigger it when walking. //Syzygy Edit.
 
 /obj/structure/wire_splicing/Initialize(roundstart)
 	.=..()
@@ -76,18 +75,12 @@
 	..()
 	to_chat(user, "It has [messiness] wire[messiness > 1?"s":""] dangling around")
 
-	if(isliving(user) && !("\ref[user]" in aware_mobs))	//Syzygy Edit.
-		to_chat(user, SPAN_NOTICE("You're aware of this wire splicing, now. You won't clumsily step on it when walking carefully."))
-		aware_mobs |= "\ref[user]"
-
 /obj/structure/wire_splicing/Crossed(AM as mob|obj)
 	if(isliving(AM))
 		var/mob/living/L = AM
 		var/turf/T = get_turf(src)
 		var/chance_to_shock = messiness * 10
 		chance_to_shock -= L.skill_to_evade_traps(chance_to_shock)
-		if(("\ref[L]" in aware_mobs) && MOVING_DELIBERATELY(L))	//Syzygy Edit.
-			return ..()
 		if(locate(/obj/structure/catwalk) in T)
 			chance_to_shock -= 20
 		if(prob(chance_to_shock))

--- a/zzz_modular_syzygy/wire_splicing.dm
+++ b/zzz_modular_syzygy/wire_splicing.dm
@@ -1,0 +1,32 @@
+/obj/structure/wire_splicing
+	name = "wire splicing"
+	desc = "Looks like someone was very drunk when doing this, or just didn't care. This can be removed by wirecutters."
+	icon = 'icons/obj/traps.dmi'
+	icon_state = "wire_splicing1"
+	density = FALSE
+	anchored = TRUE
+	flags = CONDUCT
+	layer = TURF_LAYER + 0.45
+	var/messiness = 0 // How bad the splicing was, determines the chance of shock
+	var/list/aware_mobs = list() //List of refs of mobs that examined this trap. Won't trigger it when walking. //Syzygy Edit.
+
+/obj/structure/wire_splicing/examine(mob/user)
+	..()
+	to_chat(user, "It has [messiness] wire[messiness > 1?"s":""] dangling around")
+
+	if(isliving(user) && !("\ref[user]" in aware_mobs))	//Syzygy Edit.
+		to_chat(user, SPAN_NOTICE("You're aware of this wire splicing, now. You won't clumsily step on it when walking carefully."))
+		aware_mobs |= "\ref[user]"
+
+/obj/structure/wire_splicing/Crossed(AM as mob|obj)
+	if(isliving(AM))
+		var/mob/living/L = AM
+		var/turf/T = get_turf(src)
+		var/chance_to_shock = messiness * 10
+		chance_to_shock -= L.skill_to_evade_traps(chance_to_shock)
+		if(("\ref[L]" in aware_mobs) && MOVING_DELIBERATELY(L))	//Syzygy Edit.
+			return ..()
+		if(locate(/obj/structure/catwalk) in T)
+			chance_to_shock -= 20
+		if(prob(chance_to_shock))
+			shock(L, FALSE)

--- a/zzz_modular_syzygy/wire_splicing.dm
+++ b/zzz_modular_syzygy/wire_splicing.dm
@@ -1,12 +1,6 @@
+///// MODULAR OVERRIDE TO ADD BEAR TRAP STYLE AWARENESS /////
+
 /obj/structure/wire_splicing
-	name = "wire splicing"
-	desc = "Looks like someone was very drunk when doing this, or just didn't care. This can be removed by wirecutters."
-	icon = 'icons/obj/traps.dmi'
-	icon_state = "wire_splicing1"
-	density = FALSE
-	anchored = TRUE
-	flags = CONDUCT
-	layer = TURF_LAYER + 0.45
 	var/list/aware_mobs = list() //List of refs of mobs that examined this trap. Won't trigger it when walking. //Syzygy Edit.
 
 /obj/structure/wire_splicing/examine(mob/user)

--- a/zzz_modular_syzygy/wire_splicing.dm
+++ b/zzz_modular_syzygy/wire_splicing.dm
@@ -11,7 +11,6 @@
 
 /obj/structure/wire_splicing/examine(mob/user)
 	..()
-	to_chat(user, "It has [messiness] wire[messiness > 1?"s":""] dangling around")
 
 	if(isliving(user) && !("\ref[user]" in aware_mobs))	//Syzygy Edit.
 		to_chat(user, SPAN_NOTICE("You're aware of this wire splicing, now. You won't clumsily step on it when walking carefully."))
@@ -20,12 +19,6 @@
 /obj/structure/wire_splicing/Crossed(AM as mob|obj)
 	if(isliving(AM))
 		var/mob/living/L = AM
-		var/turf/T = get_turf(src)
-		var/chance_to_shock = messiness * 10
-		chance_to_shock -= L.skill_to_evade_traps(chance_to_shock)
 		if(("\ref[L]" in aware_mobs) && MOVING_DELIBERATELY(L))	//Syzygy Edit.
-			return ..()
-		if(locate(/obj/structure/catwalk) in T)
-			chance_to_shock -= 20
-		if(prob(chance_to_shock))
-			shock(L, FALSE)
+			return
+	..()

--- a/zzz_modular_syzygy/wire_splicing.dm
+++ b/zzz_modular_syzygy/wire_splicing.dm
@@ -7,7 +7,6 @@
 	anchored = TRUE
 	flags = CONDUCT
 	layer = TURF_LAYER + 0.45
-	var/messiness = 0 // How bad the splicing was, determines the chance of shock
 	var/list/aware_mobs = list() //List of refs of mobs that examined this trap. Won't trigger it when walking. //Syzygy Edit.
 
 /obj/structure/wire_splicing/examine(mob/user)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
On examination of a wire splicing, the player will be added to a list of "aware mobs" for that specific splicing, which will then allow them to WALK over the splicing without stepping on it and getting electrocuted.

![image](https://user-images.githubusercontent.com/45645502/93687185-0d2bee80-fabc-11ea-8d42-ec094fe142db.png)

The code is pretty much copied and pasted over from the bear trap awareness code, modified to not include "Deployed". 
## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It adds a small QoL feature that gives the player more of a chance against wire splicings. Currently, a 1 tile hallway with a high level splicing is impassable without getting shocked or slowly cutting up the splicing. 

## Changelog
```changelog
add: Wire splicing awareness on examination.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
