### PR TITLE
Doubles the duration of the round-end phase

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -6,7 +6,7 @@ SUBSYSTEM_DEF(ticker)
 	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME
 	wait = 1 SECONDS //Tick every second
 
-	var/const/restart_timeout = 600
+	var/const/restart_timeout = 1200	// Syzygy Edit - Doubles the duration of the round-end phase
 	var/current_state = GAME_STATE_STARTUP
 	// If true, there is no lobby phase, the game starts immediately.
 	var/start_immediately = FALSE


### PR DESCRIPTION
## About The Pull Request

You now have 120 seconds instead of 60 seconds to goof around in Centcom.

## Changelog
```changelog
tweak: Round-end phase now lasts 120 seconds, up from 60 seconds
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
