### PR TITLE
changes steady receipe

### DIFF
--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -688,7 +688,7 @@
 	holder.del_reagent("napalm")
 	return
 
-/datum/chemical_reaction/chemsmoke
+
 	result = null
 	required_reagents = list("potassium" = 1, "sugar" = 1, "phosphorus" = 1)
 	result_amount = 0.4
@@ -1862,7 +1862,7 @@
 
 /datum/chemical_reaction/steady
 	result = "steady"
-	required_reagents = list("pararein" = 1, "carpotoxin" = 1, "copper" = 1, "hydrazine" = 1)
+	required_reagents = list("pararein" = 1, "seligitillin" = 1, "copper" = 1, "hydrazine" = 1)
 	result_amount = 4
 	maximum_temperature = 338
 	minimum_temperature = 323

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -688,7 +688,7 @@
 	holder.del_reagent("napalm")
 	return
 
-
+/datum/chemical_reaction/chemsmoke
 	result = null
 	required_reagents = list("potassium" = 1, "sugar" = 1, "phosphorus" = 1)
 	result_amount = 0.4


### PR DESCRIPTION
About The Pull Request

changes steady from needing carpotoxin to needing roach chems 

## Why It's Good For The Game

Needing an RNG drop that you probably won't get for chemistry is lame. Half the time, the ship does not move. There is generally no carp on 60% of rounds. Sad!

## Changelog
```changelog
tweak: steady receipe change
```