### PR TITLE
More items for the tubular pouch to hold.

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2715,6 +2715,7 @@
 #include "zzz_modular_syzygy\hugbox.dm"
 #include "zzz_modular_syzygy\loadout.dm"
 #include "zzz_modular_syzygy\lockers.dm"
+#include "zzz_modular_syzygy\pouches.dm"
 #include "zzz_modular_syzygy\projectiles.dm"
 #include "zzz_modular_syzygy\roach.dm"
 #include "zzz_modular_syzygy\stashes.dm"

--- a/zzz_modular_syzygy/pouches.dm
+++ b/zzz_modular_syzygy/pouches.dm
@@ -1,3 +1,5 @@
+///// Additional items that can be fitted in the tubular pouch belt /////
+
 /obj/item/weapon/storage/pouch/tubular/New()
 	..()
 	can_hold += list(

--- a/zzz_modular_syzygy/pouches.dm
+++ b/zzz_modular_syzygy/pouches.dm
@@ -1,0 +1,31 @@
+/obj/item/weapon/storage/pouch/tubular/New()
+	..()
+	can_hold += list(
+		/obj/item/weapon/cell/medium,
+		/obj/item/weapon/cell/small,
+		/obj/item/weapon/tool/screwdriver,
+		/obj/item/weapon/melee/telebaton,
+		/obj/item/weapon/reagent_containers/spray/pepper,
+		/obj/item/weapon/reagent_containers/spray/luminol,
+		/obj/item/weapon/reagent_containers/spray/cleaner,
+		/obj/item/weapon/reagent_containers/spray/plantbgone,
+		/obj/item/weapon/reagent_containers/spray/sterilizine,
+		/obj/item/weapon/plantspray/pests,
+		/obj/item/device/flash,
+		/obj/item/weapon/tank/emergency_oxygen,
+		/obj/item/weapon/reagent_containers/food/drinks/cans,
+		/obj/item/weapon/extinguisher/mini,
+		/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
+		/obj/item/device/robotanalyzer,
+		/obj/item/weapon/tool_upgrade/augment/fuel_tank,
+		/obj/item/weapon/tool_upgrade/productivity/oxyjet,
+		/obj/item/weapon/tool_upgrade/refinement/ported_barrel,
+		/obj/item/weapon/light/tube,
+		/obj/item/weapon/implanter,
+		/obj/item/weapon/tool/cautery,
+		/obj/item/weapon/tool/scalpel,
+		/obj/item/weapon/tool/hemostat,
+		/obj/item/weapon/tool/retractor,
+		/obj/item/weapon/tool/bonesetter,
+		/obj/item/weapon/grenade
+		)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
A small little addition to add more items to the list of storable items in tubular pouch belts. All of the stuff is cylindrical in shape and mostly small size, or fitting within reason. 

A new modular folder was added that anyone can add more stuff to if need be. I only walked around the ship for an hour and added the stuff I found along the way. I'm sure I missed stuff that could also be added to the list.

![image](https://user-images.githubusercontent.com/45645502/93849978-7888e280-fcad-11ea-8d03-ae41d46e1179.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It gives more of a reason to use the tubular pouch. Players complained about it being borderline useless.

## Changelog
```changelog
tweak: Tweaked/added to the list of objects the tubular pouch can hold.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
