### PR TITLE
Implements crew transfer votes

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2719,6 +2719,7 @@
 #include "zzz_modular_syzygy\projectiles.dm"
 #include "zzz_modular_syzygy\roach.dm"
 #include "zzz_modular_syzygy\stashes.dm"
+#include "zzz_modular_syzygy\vote.dm"
 #include "zzz_modular_syzygy\wire_splicing.dm"
 #include "zzz_modular_syzygy\storytellers\mentor.dm"
 // END_INCLUDE

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -247,6 +247,7 @@ SUBSYSTEM_DEF(ticker)
 		generate_excel_contracts(min(6 + round(minds.len / 5), 12))
 		excel_check()
 		addtimer(CALLBACK(src, .proc/contract_tick), 15 MINUTES)
+		addtimer(CALLBACK(src, .proc/crew_transfer), 240 MINUTES)	// SYZYGY EDIT - Crew transfer vote, initially starts 4 hours in. Check zzz_modular_syzygy/vote.dm for the actual vote
 	//start_events() //handles random events and space dust.
 	//new random event system is handled from the MC.
 

--- a/zzz_modular_syzygy/vote.dm
+++ b/zzz_modular_syzygy/vote.dm
@@ -1,0 +1,26 @@
+// Syzygy's crew transfer vote stuff and other vote-related overrides go here
+
+/datum/poll/evac
+	next_vote = 30 MINUTES //Minimum round length before it can be called for the first time, set to 30 minutes from 90
+
+/datum/controller/subsystem/ticker/proc/crew_transfer()
+	if(!SSvote.active_vote)
+		SSvote.autocrew_transfer()
+	addtimer(CALLBACK(src, .proc/crew_transfer), 60 MINUTES)	//Starts another vote an hour later
+
+/datum/controller/subsystem/vote/proc/autocrew_transfer()
+	start_vote(/datum/poll/evac/transfer)
+
+/datum/poll/evac/transfer
+	name = "Engage Bluespace Drive"
+	question = "Do you want to jump to another sector of space and restart the round?"
+	choice_types = list(/datum/vote_choice/transfer, /datum/vote_choice/notransfer)
+
+/datum/vote_choice/transfer
+	text = "Spool up the Bluespace Drive!"
+
+/datum/vote_choice/transfer/on_win()
+	evacuation_controller.call_evacuation(null, FALSE, TRUE, FALSE, TRUE)
+
+/datum/vote_choice/notransfer
+	text = "Remain here for the next hour"


### PR DESCRIPTION
## About The Pull Request
This PR will make the server automatically start a crew transfer vote 4 hours into the round. It will then start one every hour after that.

In addition, this PR will make it so that players can vote for a full-on evacuation half an hour into the round, down from an hour and a half.

## Changelog
```changelog Toriate
add: Crew Transfer Votes! First one starts 4 hours into a round, then every hour after that.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
