### PR TITLE
Maps in more AED cabinets

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -4073,6 +4073,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/structure/defibcabinet{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
 "ajr" = (
@@ -5540,6 +5543,9 @@
 /area/eris/security/exerooms)
 "amA" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/defibcabinet{
+	pixel_y = -28
+	},
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
 "amB" = (
@@ -6994,6 +7000,9 @@
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
+	},
+/obj/structure/defibcabinet{
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/eschangarb)
@@ -71676,6 +71685,9 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
+/obj/structure/defibcabinet{
+	pixel_x = 28
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/command/meeting_room)
 "dek" = (
@@ -101611,6 +101623,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/defibcabinet{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/bar)
 "esT" = (
@@ -103078,6 +103093,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/defibcabinet{
+	pixel_y = 32
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
@@ -108843,6 +108861,15 @@
 /obj/item/weapon/storage/freezer/contains_food,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/rnd/research)
+"lgz" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/defibcabinet{
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/steel,
+/area/eris/crew_quarters/sleep/cryo)
 "liQ" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -210807,7 +210834,7 @@ cWA
 dzr
 cYj
 cRM
-bsE
+lgz
 bAp
 daC
 bON


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![dreamseeker_XqA9JauXO7](https://user-images.githubusercontent.com/31995558/94075354-9d0bc880-fe2d-11ea-86b7-1f21e1329e9c.png) ![dreamseeker_WM0Z86UnrR](https://user-images.githubusercontent.com/31995558/94075359-9ed58c00-fe2d-11ea-8f22-e3c0cef851df.png) 
![dreamseeker_8MOH2R82fc](https://user-images.githubusercontent.com/31995558/94075363-a09f4f80-fe2d-11ea-944d-3abd5c0b792d.png) ![dreamseeker_iST1x3bMqW](https://user-images.githubusercontent.com/31995558/94075370-a2691300-fe2d-11ea-9898-26a496e6a909.png)
![dreamseeker_FaWIBUFc7L](https://user-images.githubusercontent.com/31995558/94075401-b4e34c80-fe2d-11ea-8fe5-a4962aa280ac.png) ![dreamseeker_FiBSdpi52m](https://user-images.githubusercontent.com/31995558/94075403-b6ad1000-fe2d-11ea-8d24-55465f03b774.png)
![dreamseeker_iqF4nfyRs2](https://user-images.githubusercontent.com/31995558/94075404-b745a680-fe2d-11ea-8a10-244ccd971a19.png)

Aft cryo, Dorms, the bar, and escape hangar B now get publicly accessible AEDs. Cargo, Security, and the Bridge gets one as well.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
add: Mapped in a bunch of AED cabinets all over the ship
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
