### PR TITLE
Adds a minimum crew requirement for Hivemind and Blob

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2720,5 +2720,6 @@
 #include "zzz_modular_syzygy\roach.dm"
 #include "zzz_modular_syzygy\stashes.dm"
 #include "zzz_modular_syzygy\wire_splicing.dm"
+#include "zzz_modular_syzygy\storytellers\events.dm"
 #include "zzz_modular_syzygy\storytellers\mentor.dm"
 // END_INCLUDE

--- a/zzz_modular_syzygy/storytellers/events.dm
+++ b/zzz_modular_syzygy/storytellers/events.dm
@@ -1,0 +1,7 @@
+// Syzygy's overrides for storyteller events go here
+
+/datum/storyevent/hivemind
+	req_crew = 9	//Makes it so that at least 9 players must be playing in order to spawn
+
+/datum/storyevent/blob
+	req_crew = 6


### PR DESCRIPTION
## About The Pull Request
Hivemind now needs 9 crew before spawning, and Blob needs 6.

## Changelog
```changelog Toriate
balance: Added a minimum crew requirement for Hivemind and Blob
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
