### PR TITLE
Makes the Energy Armblade Implant stop despawning itself (#5485)

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -192,6 +192,7 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	var/mob/living/creator
 	var/datum/effect/effect/system/spark_spread/spark_system
+	var/cleanup = TRUE	// Should the blade despawn moments after being discarded by the summoner?
 
 /obj/item/weapon/melee/energy/blade/New()
 
@@ -207,10 +208,12 @@
 
 /obj/item/weapon/melee/energy/blade/attack_self(mob/user as mob)
 	user.drop_from_inventory(src)
-	spawn(1) if(src) qdel(src)
+	if(cleanup)
+		spawn(1) if(src) qdel(src)
 
 /obj/item/weapon/melee/energy/blade/dropped()
-	spawn(1) if(src) qdel(src)
+	if(cleanup)
+		spawn(1) if(src) qdel(src)
 
 /obj/item/weapon/melee/energy/blade/Process()
 	if(!creator || loc != creator || (creator.l_hand != src && creator.r_hand != src))
@@ -225,9 +228,11 @@
 			host.pinned -= src
 			host.embedded -= src
 			host.drop_from_inventory(src)
-		spawn(1) if(src) qdel(src)
+		if(cleanup)
+			spawn(1) if(src) qdel(src)
 
 /obj/item/weapon/melee/energy/blade/organ_module //just to make sure that blade doesnt delet itself
+	cleanup = FALSE
 
 /obj/item/weapon/melee/energy/blade/organ_module/New()
 


### PR DESCRIPTION
## About The Pull Request
This is literally just my PR from upstream, being ported down.

https://github.com/discordia-space/CEV-Eris/pull/5485

## Changelog
```changelog Toriate
fix: Energy Armblade Implant should no longer delete itself a minute after first use
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
