### PR TITLE
Map fixes and more!

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2737,6 +2737,7 @@
 #include "zzz_modular_syzygy\hugbox.dm"
 #include "zzz_modular_syzygy\loadout.dm"
 #include "zzz_modular_syzygy\lockers.dm"
+#include "zzz_modular_syzygy\oddities.dm"
 #include "zzz_modular_syzygy\pixelshift.dm"
 #include "zzz_modular_syzygy\plasma.dm"
 #include "zzz_modular_syzygy\pouches.dm"

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -50675,7 +50675,11 @@
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 4;
-	pixel_x = 11
+	icon_state = "pdoor0";
+	id = "SecondSectionLockdown";
+	layer = 2.6;
+	name = "Second Section Lockdown";
+	pixel_x = 0
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section2)
@@ -104884,11 +104888,11 @@
 	opacity = 0
 	},
 /obj/machinery/door/blast/shutters{
-	density = 0;
+	density = 1;
 	dir = 2;
 	id = "rnddesk";
 	name = "Research Desk Shutters";
-	opacity = 0
+	opacity = 1
 	},
 /obj/machinery/door/window/westleft{
 	name = "Research Desk";


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR will fix the dislodged blastdoor and closed-but-actually-open RnD shutters. In addition, a file that was forgotten from the .dme has been properly included, fixing some oddity descriptions.

## Changelog
```changelog Toriate
fix: Second section blastdoor is no longer dislodged from its frame and seemingly shut.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
