### PR TITLE
Adds a surplus gun mods crate

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2731,6 +2731,7 @@
 #include "zzz_modular_syzygy\ammo.dm"
 #include "zzz_modular_syzygy\cargoexports.dm"
 #include "zzz_modular_syzygy\clothing.dm"
+#include "zzz_modular_syzygy\crates.dm"
 #include "zzz_modular_syzygy\defib.dm"
 #include "zzz_modular_syzygy\defiblocker.dm"
 #include "zzz_modular_syzygy\grenades.dm"

--- a/zzz_modular_syzygy/crates.dm
+++ b/zzz_modular_syzygy/crates.dm
@@ -1,0 +1,19 @@
+// Syzygy's snowflake crates go here
+
+/datum/supply_pack/randomised/gunmods
+	num_contained = 4
+	contains = list(/obj/item/weapon/gun_upgrade/mechanism/weintraub,
+                /obj/item/weapon/gun_upgrade/barrel/forged,
+                /obj/item/weapon/gun_upgrade/muzzle/silencer,
+                /obj/item/weapon/gun_upgrade/trigger/cop_block,
+                /obj/item/weapon/gun_upgrade/trigger/dangerzone,
+                /obj/item/weapon/gun_upgrade/mechanism/overshooter,
+                /obj/item/weapon/gun_upgrade/barrel/excruciator,
+                /obj/item/weapon/gun_upgrade/scope/watchman,
+                /obj/item/weapon/tool_upgrade/refinement/laserguide
+                )
+	name = "Surplus Gun Parts"
+	cost = 2000
+	crate_name = "Surplus Gun Parts Crate"
+	containertype = /obj/structure/closet/crate
+	group = "Operations"


### PR DESCRIPTION
## About The Pull Request

This PR adds the surplus gun parts crate, which can be ordered from cargo. It simply allows you to purchase formerly maint-only gun mods that are excessively rare.

![7BVvkOBjWh](https://user-images.githubusercontent.com/31995558/94996197-ac310a00-05d5-11eb-9c6c-63c5d7361cfe.png) ![dreamseeker_1Cj1wjhmZr](https://user-images.githubusercontent.com/31995558/94996198-adfacd80-05d5-11eb-8c54-319fe5f23e02.png)

## Changelog
```changelog Toriate
add: Surplus gun parts crates are now available to order from cargo!
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
