### PR TITLE
changes frozen star vendor messages in vending.dm

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -990,7 +990,7 @@
 /obj/machinery/vending/weapon_machine
 	name = "Frozen Star Guns&Armor"
 	desc = "A self-defense equipment vending machine. When you need to take care of that clown."
-	product_slogans = "The best defense is good offense!;Buy for your whole family today!;Nobody can outsmart bullet!;God created man - Frozen Star made them EQUAL!;Stupidity can be cured. By LEAD!;Dead kulaks can't exploit your labor!;Now with blue and pink tracers for the ultimate gender reveal party!"
+	product_slogans = "The best defense is good offense!;Buy for your whole family today!;Nobody can outsmart bullet!;God created man - Frozen Star made them EQUAL!;Stupidity can be cured. By LEAD!;Now with blue and pink tracers for the ultimate gender reveal party!"
 	product_ads = "Stunning!;Take justice in your own hands!;LEADearship!"
 	icon_state = "weapon"
 	no_criminals = TRUE

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -990,7 +990,7 @@
 /obj/machinery/vending/weapon_machine
 	name = "Frozen Star Guns&Armor"
 	desc = "A self-defense equipment vending machine. When you need to take care of that clown."
-	product_slogans = "The best defense is good offense!;Buy for your whole family today!;Nobody can outsmart bullet!;God created man - Frozen Star made them EQUAL!;Stupidity can be cured! By LEAD.;Dead kids can't bully your children!"
+	product_slogans = "The best defense is good offense!;Buy for your whole family today!;Nobody can outsmart bullet!;God created man - Frozen Star made them EQUAL!;Stupidity can be cured. By LEAD!;Dead kulaks can't exploit your labor!;Now with blue and pink tracers for the ultimate gender reveal party!"
 	product_ads = "Stunning!;Take justice in your own hands!;LEADearship!"
 	icon_state = "weapon"
 	no_criminals = TRUE

--- a/zzz_modular_syzygy/storytellers/lookout.dm
+++ b/zzz_modular_syzygy/storytellers/lookout.dm
@@ -5,7 +5,7 @@
 	description = "A quiet storyteller that lets the ship speak for itself."
 
 	gain_mult_mundane = 0.8
-	gain_mult_moderate = 0.8
+	gain_mult_moderate = 0.85
 	gain_mult_major = 0.6 //STFU MY SHIT IS ON WHAT'S NEW SCOOBY DOO
 	gain_mult_roleset = 0.9
 
@@ -16,7 +16,7 @@
 	//Generates few events after spawning antagonists.
 	points = list(
 	EVENT_LEVEL_MUNDANE = 0, //Mundane
-	EVENT_LEVEL_MODERATE = 0, //Moderate
+	EVENT_LEVEL_MODERATE = 10, //Moderate
 	EVENT_LEVEL_MAJOR = 0, //Major
 	EVENT_LEVEL_ROLESET = 220 //Roleset. Spawn one antag immediately, and another quickly.
 	)


### PR DESCRIPTION
## About The Pull Request

Changes frozen star vendor messages. Also like, minorly changes lookout.dm since it's just a shitty bugfix. Basically, minor and moderate events kept spawning at the same time.

## Why It's Good For The Game

'Dead kids can't bully your children!' is the type of thing that's so edgy you can use it to fillet a fish.
De-syncs lookout event spawns.

## Changelog
```changelog
tweak: un-edgifies the frozen star vendors
tweak: lookout storyteller fixes.
```
