### PR TITLE
Giant spider naming

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2733,6 +2733,7 @@
 #include "zzz_modular_syzygy\clothing.dm"
 #include "zzz_modular_syzygy\defib.dm"
 #include "zzz_modular_syzygy\defiblocker.dm"
+#include "zzz_modular_syzygy\giant_spider.dm"
 #include "zzz_modular_syzygy\grenades.dm"
 #include "zzz_modular_syzygy\hugbox.dm"
 #include "zzz_modular_syzygy\loadout.dm"

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
@@ -1,6 +1,6 @@
 //basic spider mob, these generally guard nests
 /mob/living/carbon/superior_animal/giant_spider
-	//name = "giant spider" syz edit, name in modular folder
+	name = "giant spider"
 	desc = "Furry and black, it makes you shudder to look at it. This one has deep red eyes."
 	icon_state = "guard"
 	icon_living = "guard"

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
@@ -1,6 +1,6 @@
 //basic spider mob, these generally guard nests
 /mob/living/carbon/superior_animal/giant_spider
-	name = "giant spider"
+	//name = "giant spider" syz edit, name in modular folder
 	desc = "Furry and black, it makes you shudder to look at it. This one has deep red eyes."
 	icon_state = "guard"
 	icon_living = "guard"

--- a/zzz_modular_syzygy/giant_spider.dm
+++ b/zzz_modular_syzygy/giant_spider.dm
@@ -1,8 +1,8 @@
 /mob/living/carbon/superior_animal/giant_spider
-    name = "Senshi Spider"
+    name = "Bushi Spider"
 
 /mob/living/carbon/superior_animal/giant_spider/hunter
-    name = "Hantā Spider"
+    name = "Ryoshi Spider"
 
 /mob/living/carbon/superior_animal/giant_spider/nurse
-    name = "Josanpu Spider"
+    name = "Kango Spider"

--- a/zzz_modular_syzygy/giant_spider.dm
+++ b/zzz_modular_syzygy/giant_spider.dm
@@ -1,0 +1,8 @@
+/mob/living/carbon/superior_animal/giant_spider
+    name = "Senshi Spider"
+
+/mob/living/carbon/superior_animal/giant_spider/hunter
+    name = "Hantā Spider"
+
+/mob/living/carbon/superior_animal/giant_spider/nurse
+    name = "Josanpu Spider"


### PR DESCRIPTION

## About The Pull Request
 Adds names for the three types of giant spiders- Japanese to contrast the German roaches.

~~The 'regular' spiders are Senshi, or soldier~~

~~Hunters are Hantā, or... hunter.~~

~~Nurses are Josanpu, or midwife~~

Toriate chose different names ask him what they mean


## Why It's Good For The Game

Adds more flavor. It also makes the three different spider types a little more distinct, with different names to go with their different sprites and effects.

## Changelog
```changelog
add: Names for the giant spiders!
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
