### PR TITLE
Actually gives access to acolytes and preachers, and make soulcrypts show up on medical scanners

### DIFF
--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -16,7 +16,7 @@
 	)
 
 	access = list(
-		access_RC_announce, access_keycard_auth, access_heads, access_sec_doors
+		access_RC_announce, access_keycard_auth, access_heads, access_sec_doors, access_morgue, access_chapel_office, access_crematorium, access_hydroponics, access_janitor, access_maint_tunnels	//SYZYGY EDIT - transcribes preacher cruciform access onto their ID
 	)
 
 	wage = WAGE_PROFESSIONAL //The church has deep pockets
@@ -75,6 +75,7 @@
 	selection_color = "#ecd37d"
 	also_known_languages = list(LANGUAGE_CYRILLIC = 10)
 	cruciform_access = list(access_morgue, access_crematorium, access_maint_tunnels, access_hydroponics)
+	access = list(access_morgue, access_crematorium, access_maint_tunnels, access_hydroponics)	//SYZYGY EDIT - transcribes acolyte cruciform access onto their ID
 	wage = WAGE_PROFESSIONAL
 	outfit_type = /decl/hierarchy/outfit/job/church/acolyte
 
@@ -86,7 +87,8 @@
 	)
 
 	core_upgrades = list(
-		CRUCIFORM_PRIEST
+		CRUCIFORM_PRIEST,
+		CRUCIFORM_REDLIGHT	//As compensation for not being able to actually spawn as the preacher
 	)
 
 	description = "You serve the Chaplain as a disciple of the Faith.<br>\

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -145,7 +145,8 @@
 		/obj/item/weapon/implant/death_alarm,
 		/obj/item/weapon/implant/tracking,
 		/obj/item/weapon/implant/core_implant/cruciform,
-		/obj/item/weapon/implant/excelsior
+		/obj/item/weapon/implant/excelsior,
+		/obj/item/weapon/implant/soulcrypt		//SYZYGY EDIT - Makes soulcrypts show up properly on scanners
 	)
 	var/delete
 	var/temphtml


### PR DESCRIPTION
## About The Pull Request

Preacher's still literally unplayable for reasons unknown and cruciform access is still broken, but this should actually make acolytes playable.

In addition, acolytes have been given the same cruciform upgrades as the preacher as compensation for preacher being literally unplayable.

Furthermore, I figured out how to make soulcrypts show up properly on medical scanners while testing these changes, so here it is, in a badly atomized PR.

Changes are non-modular, but marked properly.

## Changelog
```changelog Toriate
add: Soulcrypts now show up properly in medical scanner reports
add: Acolytes now get proper access on their IDs, and they also get the preacher's cruciform upgrades as compensation for preacher being unselectable
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
