### PR TITLE
Quality of Life Improvements for Roleplayers and more

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2744,6 +2744,7 @@
 #include "zzz_modular_syzygy\levergun.dm"
 #include "zzz_modular_syzygy\loadout.dm"
 #include "zzz_modular_syzygy\lockers.dm"
+#include "zzz_modular_syzygy\multiline_me.dm"
 #include "zzz_modular_syzygy\oddities.dm"
 #include "zzz_modular_syzygy\pixelshift.dm"
 #include "zzz_modular_syzygy\plasma.dm"

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -59,7 +59,7 @@
 #define WAIT_FINISH  4
 
 // Setting this much higher than 1024 could allow spammers to DOS the server easily.
-#define MAX_MESSAGE_LEN       1024
+#define MAX_MESSAGE_LEN       2048		//Syzygy edit: What's the WORST that could happen? - Inspired by Citadel's edit
 #define MAX_PAPER_MESSAGE_LEN 3072
 #define MAX_BOOK_MESSAGE_LEN  9216
 #define MAX_LNAME_LEN         64

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -49,7 +49,7 @@ ADMIN_VERB_ADD(/client/proc/cmd_admin_pm_panel, R_ADMIN|R_MOD|R_MENTOR, FALSE)
 
 	//get message text, limit it's length.and clean/escape html
 	if(!msg)
-		msg = input(src,"Message:", "Private message to [key_name(C, 0, holder ? 1 : 0)]") as text|null
+		msg = input(src,"Message:", "Private message to [key_name(C, 0, holder ? 1 : 0)]") as message|null	//SYZYGY EDIT - Multiline textbox for PMs
 
 		if(!msg)	return
 		if(!C)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -12,7 +12,7 @@
 
 	set_typing_indicator(TRUE)
 	hud_typing = TRUE
-	var/message = input("", "say (text)") as text
+	var/message = input("", "say (text)") as text|null	//SYZYGY EDIT - So you can click cancel right away.
 	hud_typing = FALSE
 	set_typing_indicator(FALSE)
 	if(message)
@@ -35,7 +35,7 @@
 
 	set_typing_indicator(TRUE)
 	hud_typing = TRUE
-	var/message = input("", "me (text)") as text
+	var/message = input("", "me (text)") as message|null	//SYZYGY EDIT - Multiline textbox
 	hud_typing = FALSE
 	set_typing_indicator(FALSE)
 	if(message)
@@ -160,7 +160,7 @@
 //returns the language object only if the code corresponds to a language that src can speak, otherwise null.
 /mob/proc/parse_language(message)
 	var/prefix = copytext(message, 1, 2)
-	
+
 	if(length(message) >= 1 && prefix == get_prefix_key(/decl/prefix/audible_emote))
 		return all_languages["Noise"]
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -35,7 +35,7 @@
 
 	set_typing_indicator(TRUE)
 	hud_typing = TRUE
-	var/message = input("", "me (text)") as message|null	//SYZYGY EDIT - Multiline textbox
+	var/message = input("", "me (text)") as text|null	//SYZYGY EDIT - So you can click cancel right away.
 	hud_typing = FALSE
 	set_typing_indicator(FALSE)
 	if(message)

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -110,6 +110,7 @@ Any-Mode: (hotkey doesn't need to be on)
 \tPGUP = swap-hand
 \tPGDN = activate held object
 \tEND = throw
+\tm = multiline input menu for emotes
 </font>"}
 
 	var/robot_hotkey_mode = {"<font color='purple'>

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -353,6 +353,9 @@ macro "macro"
 		name = "CTRL+SHIFT+G"
 		command = ".configure graphics-hwmode on"
 	elem 
+		name = "M"
+		command = "me-multiline-verb"
+	elem 
 		name = "CTRL+Q"
 		command = ".northwest"
 	elem 
@@ -591,6 +594,9 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+J"
 		command = "toggle-gun-mode"
+	elem 
+		name = "M"
+		command = "me-multiline-verb"
 	elem 
 		name = "Q"
 		command = ".northwest"

--- a/zzz_modular_syzygy/multiline_me.dm
+++ b/zzz_modular_syzygy/multiline_me.dm
@@ -1,0 +1,13 @@
+// Syzygy's wonky seperate multiline me stuff goes here
+
+/mob/verb/me_wrapper_multline()
+	set name = "Me multiline verb"
+	set category = "IC"
+
+	set_typing_indicator(TRUE)
+	hud_typing = TRUE
+	var/message = input("", "me (text)") as message|null	//SYZYGY EDIT - Multiline textbox
+	hud_typing = FALSE
+	set_typing_indicator(FALSE)
+	if(message)
+		me_verb(message)


### PR DESCRIPTION
## About The Pull Request
The maximum message length has been doubled from 1024 characters to 2048 characters.

In addition, pressing M will now open up a multiline /Me input box, just like Citadel's.

Furthermore, the admin PM to player textboxes are also multiline now.

Lastly, the say textbox gets a cancel button now.

## Why It's Good For The Game
Now everyone can enjoy their enterprise resource planning without being interrupted by arbitrary message length limitations!

## Changelog
```changelog Toriate
add: You can now press M to open up a multiline Me textbox.
tweak: Maximum message length has been doubled from 1024 characters to 2048 characters.
admin: Admin PMs to players are now a multiline textbox.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
