### PR TITLE
Economy Tweaks

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2755,6 +2755,7 @@
 #include "zzz_modular_syzygy\vote.dm"
 #include "zzz_modular_syzygy\wire_splicing.dm"
 #include "zzz_modular_syzygy\code\game\jobs\SZdepartment.dm"
+#include "zzz_modular_syzygy\code\modules\economy\price_list_fixed.dm"
 #include "zzz_modular_syzygy\prosthesis\prosthesis_brands.dm"
 #include "zzz_modular_syzygy\prosthesis\prosthesis_parts.dm"
 #include "zzz_modular_syzygy\storytellers\events.dm"

--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2754,6 +2754,7 @@
 #include "zzz_modular_syzygy\stashes.dm"
 #include "zzz_modular_syzygy\vote.dm"
 #include "zzz_modular_syzygy\wire_splicing.dm"
+#include "zzz_modular_syzygy\code\game\jobs\SZdepartment.dm"
 #include "zzz_modular_syzygy\prosthesis\prosthesis_brands.dm"
 #include "zzz_modular_syzygy\prosthesis\prosthesis_parts.dm"
 #include "zzz_modular_syzygy\storytellers\events.dm"

--- a/code/modules/economy/price_list.dm
+++ b/code/modules/economy/price_list.dm
@@ -1078,10 +1078,11 @@
 
 /obj/item/weapon/reagent_containers/price_tag = 20
 /obj/item/weapon/reagent_containers/glass/beaker/bluespace/price_tag = 300
+/* SYZYGY Edit - This NEEDS to be commented out due to the way it's fucking coded. Because Eris coders hate us.
 /obj/item/weapon/reagent_containers/get_item_cost(export)
 	. = ..()
 	. += reagents.total_volume * .
-
+*/
 /obj/item/clothing/price_tag = 30
 /obj/item/solar_assembly/price_tag = 100
 /obj/item/weapon/tracker_electronics/price_tag = 150

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -737,47 +737,6 @@
 			<ul class="changes bgimages16">
 				<li class="config">Automatic changelog generation has been enabled for SyzygyStation/Syzygy-Eris</li>
 			</ul>
-
-			<h2 class="date">04 August 2020</h2>
-			<h3 class="author">Chatter42 updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">wearing a space suit will prevent trash piles from cutting your hands</li>
-				<li class="bugfix">trash piles will correctly cut your hands instead of your arms when you are digging through them</li>
-			</ul>
-			<h3 class="author">Fernandos33 updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="tweak">mines are now overlayed like traps</li>
-				<li class="balance">frag from excels mines where lowered</li>
-			</ul>
-			<h3 class="author">Kurgis, Près de l'oiseau updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">Brand new collectable figurines, winnable from the arcade as per usual.</li>
-				<li class="rscdel">Removed the farwa plushie, removed the unused (and broken) therapy dolls.</li>
-				<li class="imageadd">Près de l'oiseau's new figurine sprites.</li>
-				<li class="imagedel">Deleted some unused objects from toys.dmi, they will not be missed.</li>
-			</ul>
-			<h3 class="author">SirSiggles updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscdel">Removed Eris mentions.</li>
-				<li class="tweak">Rewrote Species Blurbs.</li>
-			</ul>
-			<h3 class="author">drexample updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="tweak">Standing mobs can't hide behind organs anymore.</li>
-				<li class="balance">Blitzshell nanorepair now have 5 minutes cooldown.</li>
-				<li class="tweak">Priest and acolyte jacket should at least protect as much as a labcoat from bio damage</li>
-				<li class="bugfix">No more powder piles and chem splashes in open space.</li>
-				<li class="bugfix">Deconstruction of lattice, catwalk and railings would drop items under your feet.</li>
-				<li class="tweak">spawning in should no longer make you stunned for as long.</li>
-				<li class="tweak">Borgs/Drones light replacer recharges faster</li>
-				<li class="tweak">it should no longer be possible to spam player-made wire splices</li>
-				<li class="bugfix">making splices bigger is now properly functional</li>
-				<li class="bugfix">noexcutite now can be made again</li>
-				<li class="bugfix">mirc will now properly display boxer recipe</li>
-				<li class="balance">Re-adjusted the Lasblender's damage values, remember to use weapon attachments to increase its power.</li>
-				<li class="tweak">Adjusted the speed of Serbian shuttle travel time from 7 minutes to 3.</li>
-				<li class="bugfix">You are able to throw things and mobs over open space now.</li>
-			</ul>
 <br>
 <b>CEV Eris Development Team</b>
 	<div class = "top">

--- a/zzz_modular_syzygy/code/game/jobs/SZdepartment.dm
+++ b/zzz_modular_syzygy/code/game/jobs/SZdepartment.dm
@@ -1,5 +1,4 @@
 /datum/department/guild
-	..()
 	account_initial_balance = 12000
 	
 /datum/department/civilian
@@ -14,11 +13,9 @@
 	*/
 
 /datum/job/clubworker
-	..()
 	wage = WAGE_LABOUR_DUMB //Club workers make less than professional wages and are expected to make up the difference in tips.
 
 /datum/job/clubmanager
-	..()
 	department_account_access = TRUE
 	/* The manager is not command, but is responsible for ensuring that his workers,
 	custodians, and botanists get paid

--- a/zzz_modular_syzygy/code/game/jobs/SZdepartment.dm
+++ b/zzz_modular_syzygy/code/game/jobs/SZdepartment.dm
@@ -1,0 +1,25 @@
+/datum/department/guild
+	..()
+	account_initial_balance = 12000
+
+/datum/department/civilian
+	name = "The Club"
+	id = DEPARTMENT_CIVILIAN
+	account_initial_balance = 2000 // Less vital than most departments and smaller
+	account_budget = 1000 //A small stipend that the manager can distribute as he sees fit.
+	/*
+		This account pays out to club workers, hydroponics, and custodians.
+		It is managed by The Club manager.
+
+	*/
+
+/datum/job/clubworker
+	..()
+	wage = WAGE_LABOUR_DUMB //Club workers make less than professional wages and are expected to make up the difference in tips.
+
+/datum/job/clubmanager
+	..()
+	department_account_access = TRUE
+	/* The manager is not command, but is responsible for ensuring that his workers,
+	custodians, and botanists get paid
+	*/

--- a/zzz_modular_syzygy/code/game/jobs/SZdepartment.dm
+++ b/zzz_modular_syzygy/code/game/jobs/SZdepartment.dm
@@ -1,7 +1,7 @@
 /datum/department/guild
 	..()
 	account_initial_balance = 12000
-
+	
 /datum/department/civilian
 	name = "The Club"
 	id = DEPARTMENT_CIVILIAN

--- a/zzz_modular_syzygy/code/modules/economy/price_list_fixed.dm
+++ b/zzz_modular_syzygy/code/modules/economy/price_list_fixed.dm
@@ -1,0 +1,457 @@
+//***************//
+//---Beverages---//
+//***************//
+
+// Juices, soda and similar //
+
+/datum/reagent/water
+	price_tag = 0 //We can get infinate amounts of water
+
+/datum/reagent/drink/juice
+	price_tag = 1 //We can generate infinate amounts of juice with no effort
+
+/datum/reagent/toxin/poisonberryjuice
+	price_tag = 2
+
+/datum/reagent/drink/milk
+	price_tag = 2
+
+/datum/reagent/drink/soda
+	price_tag = 1 //We can generate infinate amounts of soda with no effort
+
+/datum/reagent/drink/doctor_delight
+	price_tag = 3
+
+/datum/reagent/drink/nothing
+	price_tag = 4//Actually hard to get. 400cr per bottle
+
+/datum/reagent/drink/milkshake
+	price_tag = 4
+
+/datum/reagent/drink/roy_rogers
+	price_tag = 2
+
+/datum/reagent/drink/shirley_temple
+	price_tag = 2
+
+/datum/reagent/drink/arnold_palmer
+	price_tag = 2
+
+/datum/reagent/drink/collins_mix
+	price_tag = 2
+
+
+// Beer //
+
+/datum/reagent/ethanol/ale
+	price_tag = 2
+
+/datum/reagent/ethanol/beer
+	price_tag = 2
+
+
+// Hot Drinks //
+
+/datum/reagent/drink/rewriter
+	price_tag = 1
+
+/datum/reagent/drink/tea
+	price_tag = 1//We can generate infinate amounts of tea with no effort
+
+/datum/reagent/drink/coffee
+	price_tag = 1//we can generate infinate amounts of coffee with no effort
+
+/datum/reagent/drink/hot_coco
+	price_tag = 1
+
+/obj/item/weapon/reagent_containers/food
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/coffee
+	price_tag = 0//Trash
+
+/obj/item/weapon/reagent_containers/food/drinks/tea
+	price_tag = 0//It's trash
+
+/obj/item/weapon/reagent_containers/food/drinks/h_chocolate
+	price_tag = 0//No bottle returns
+
+
+// Spirituous liquors //
+// Cheap Stuff Up to 30usd//
+
+/datum/reagent/ethanol/vodka
+	price_tag = 1
+
+/datum/reagent/ethanol/rum
+	price_tag = 1
+
+/datum/reagent/ethanol/coffee/kahlua
+	price_tag = 1
+
+/datum/reagent/ethanol/bluecuracao
+	price_tag = 1
+
+/datum/reagent/ethanol/melonliquor
+	price_tag = 1
+
+// Intermediate stuff, up to 50usd//
+
+/datum/reagent/ethanol/gin
+	price_tag = 2
+
+/datum/reagent/ethanol/absinthe
+	price_tag = 2
+
+/datum/reagent/ethanol/whiskey
+	price_tag = 2
+
+/datum/reagent/ethanol/irish_cream
+	price_tag = 2
+
+/datum/reagent/ethanol/deadrum
+	price_tag = 2
+
+/datum/reagent/ethanol/goldschlager
+	price_tag = 2
+
+/datum/reagent/ethanol/coffee/brave_bull // Not an original liquor in its own. But since it's a mix of purely Tequila
+	price_tag = 2
+
+// More expensive stuff
+
+/datum/reagent/ethanol/tequilla
+	price_tag = 3
+
+/datum/reagent/ethanol/thirteenloko
+	price_tag = 3
+
+/datum/reagent/ethanol/specialwhiskey
+	price_tag = 3
+
+// VERY expensive stuff
+
+/datum/reagent/ethanol/patron
+	price_tag = 4//Silver in it
+
+// Wines //
+
+/datum/reagent/ethanol/wine
+	price_tag = 1
+
+/datum/reagent/ethanol/sake
+	price_tag = 1
+
+/datum/reagent/ethanol/vermouth
+	price_tag = 1
+
+/datum/reagent/ethanol/cognac
+	price_tag = 3
+
+/datum/reagent/ethanol/pwine
+	price_tag = 4
+
+
+// Cocktails //
+/*
+/datum/reagent/ethanol/acid_spit
+	price_tag = 40
+
+/datum/reagent/ethanol/alliescocktail
+	price_tag = 40
+
+/datum/reagent/ethanol/aloe
+	price_tag = 4
+
+/datum/reagent/ethanol/amasec
+	price_tag = 4
+
+/datum/reagent/ethanol/andalusia
+	price_tag = 4
+
+/datum/reagent/ethanol/antifreeze
+	price_tag = 4
+
+/datum/reagent/ethanol/atomicbomb
+	price_tag = 4
+
+/datum/reagent/ethanol/coffee/b52
+	price_tag = 4
+
+/datum/reagent/ethanol/bahama_mama
+	price_tag = 4
+
+/datum/reagent/ethanol/barefoot
+	price_tag = 4
+
+/datum/reagent/ethanol/beepsky_smash
+	price_tag = 4
+
+/datum/reagent/ethanol/bilk
+	price_tag = 4
+
+/datum/reagent/ethanol/black_russian
+	price_tag = 4
+
+/datum/reagent/ethanol/bloody_mary
+	price_tag = 4
+
+/datum/reagent/ethanol/booger
+	price_tag = 4
+
+/datum/reagent/ethanol/brave_bull
+	price_tag = 4
+
+/datum/reagent/ethanol/changeling_sting
+	price_tag = 4
+
+/datum/reagent/ethanol/martini
+	price_tag = 4
+
+/datum/reagent/ethanol/cuba_libre
+	price_tag = 4
+
+/datum/reagent/ethanol/demonsblood
+	price_tag = 4
+
+/datum/reagent/ethanol/devilskiss
+	price_tag = 4
+
+/datum/reagent/ethanol/driestmartini
+	price_tag = 4
+
+/datum/reagent/ethanol/ginfizz
+	price_tag = 4
+
+/datum/reagent/ethanol/grog
+	price_tag = 4
+
+/datum/reagent/ethanol/erikasurprise
+	price_tag = 4
+
+/datum/reagent/ethanol/gargle_blaster
+	price_tag = 4
+
+/datum/reagent/ethanol/gintonic
+	price_tag = 4
+
+/datum/reagent/ethanol/hippies_delight
+	price_tag = 4
+
+/datum/reagent/ethanol/hooch
+	price_tag = 4
+
+/datum/reagent/ethanol/iced_beer
+	price_tag = 4
+
+/datum/reagent/ethanol/irishcarbomb
+	price_tag = 4
+
+/datum/reagent/ethanol/coffee/irishcoffee
+	price_tag = 4
+
+/datum/reagent/ethanol/longislandicedtea
+	price_tag = 4
+
+/datum/reagent/ethanol/manhattan
+	price_tag = 4
+
+/datum/reagent/ethanol/manhattan_proj
+	price_tag = 4
+
+/datum/reagent/ethanol/manly_dorf
+	price_tag = 4
+
+/datum/reagent/ethanol/margarita
+	price_tag = 4
+
+/datum/reagent/ethanol/mead
+	price_tag = 4
+
+/datum/reagent/ethanol/moonshine
+	price_tag = 4
+
+/datum/reagent/ethanol/neurotoxin
+	price_tag = 4
+
+/datum/reagent/ethanol/red_mead
+	price_tag = 4
+
+/datum/reagent/ethanol/sbiten
+	price_tag = 4
+
+/datum/reagent/ethanol/screwdrivercocktail
+	price_tag = 4
+
+/datum/reagent/ethanol/silencer
+	price_tag = 4
+
+/datum/reagent/ethanol/singulo
+	price_tag = 4
+
+/datum/reagent/ethanol/snowwhite
+	price_tag = 4
+
+/datum/reagent/ethanol/suidream
+	price_tag = 4
+
+/datum/reagent/ethanol/syndicatebomb
+	price_tag = 4
+
+/datum/reagent/ethanol/tequillasunrise
+	price_tag = 4
+
+/datum/reagent/ethanol/threemileisland
+	price_tag = 4
+
+/datum/reagent/ethanol/toxins_special
+	price_tag = 4
+
+/datum/reagent/ethanol/vodkamartini
+	price_tag = 4
+
+/datum/reagent/ethanol/vodkatonic
+	price_tag = 4
+
+/datum/reagent/ethanol/white_russian
+	price_tag = 4
+
+/datum/reagent/ethanol/whiskey_cola
+	price_tag = 4
+
+/datum/reagent/ethanol/whiskeysoda
+	price_tag = 4
+
+
+// Cocktails without alcohol //
+
+/datum/reagent/ethanol/bananahonk
+	price_tag = 3
+
+*/
+
+// From the machine //
+
+/obj/item/weapon/reagent_containers/food/drinks/cans/cola
+	price_tag = 1
+
+/obj/item/weapon/reagent_containers/food/drinks/cans/space_mountain_wind
+	price_tag = 1
+
+/obj/item/weapon/reagent_containers/food/drinks/cans/dr_gibb
+	price_tag = 1
+
+/obj/item/weapon/reagent_containers/food/drinks/cans/starkist
+	price_tag = 1
+
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle
+	price_tag = 1
+
+/obj/item/weapon/reagent_containers/food/drinks/cans/space_up
+	price_tag = 1
+
+/obj/item/weapon/reagent_containers/food/drinks/cans/iced_tea
+	price_tag = 1
+
+/obj/item/weapon/reagent_containers/food/drinks/cans/grape_juice
+	price_tag = 1
+
+
+//*****************//
+//--Bottle Return--//
+//*****************//
+
+// Juices, soda and similar //
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/cola
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/space_up
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/space_mountain_wind
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/orangejuice
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/cream
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/tomatojuice
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/limejuice
+	price_tag = 10
+
+
+// Beer //
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/ale
+	price_tag = 10
+
+
+// Spirituous Liquors //
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/bluecuracao
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/gin
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/kahlua
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/melonliquor
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/rum
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/tequilla
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey
+	price_tag = 10
+
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/patron
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/goldschlager
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing
+	price_tag = 10
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/grenadine
+	price_tag = 10
+
+
+// Wines //
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/wine
+	price_tag = 20
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/cognac
+	price_tag = 20
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vermouth
+	price_tag = 20
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/pwine
+	price_tag = 20
+
+/obj/item/weapon/reagent_containers/get_item_cost(export)
+	. = ..()
+	for(var/datum/reagent/R in reagents.reagent_list)
+		. += R.volume * R.price_tag


### PR DESCRIPTION
## About The Pull Request

Moves the Civilian account over to the Club Manager
Adds a departmental fund to the civilian account
Increases base pay for the Union account
Adds a small wage for club workers.

## Why It's Good For The Game

Club workers simply put, can't really sustain themselves due to low population
A bit more roundstart humph for the Union
Fixed a major bug with how reagents interacted with exports.
Rebalanced ethanol prices.

## Changelog
```changelog
balance: added base pay for club workers
balance: increased starting union account value
balance: adjusted booze export values to be somewhat in line with prices IRL. Booze is valued between 100-400cr a bottle
fix: fixed reagent calculations for exports.
tweak: club manager now can access the civilian account
tweak: civilian account now has funds
```