### PR TITLE
Yet Another Batch of Cherry Picked PRs for New Features, Bugfixes and QoL Improvements

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -169,6 +169,8 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 	var/use_lib_nudge = 0 //Use the C library nudge instead of the python nudge.
 	var/use_overmap = 0
 
+	var/start_location = "asteroid" // Start location defaults to asteroid.
+
 	// Event settings
 	var/expected_round_length = 3 * 60 * 60 * 10 // 3 hours
 	// If the first delay has a custom start time
@@ -726,8 +728,27 @@ GLOBAL_LIST_EMPTY(storyteller_cache)
 
 				if("webhook_url")
 					config.webhook_url = value
+				
+		
+				if("random_start")
+					var/list/startlist = list(
+						"asteroid", 
+						"abandoned fortress", 
+						"space ruins") 
+					var/pick = rand(1, startlist.len)
+					config.start_location = startlist[pick]
+
+				if("asteroid_start")
+					config.start_location = "asteroid"
+
+				if("fortress_start")
+					config.start_location = "abandoned fortress"
+
+				if("ruins_start")
+					config.start_location = "space ruins"
 				else
 					log_misc("Unknown setting in configuration: '[name]'")
+
 
 		else if(type == "game_options")
 			if(!value)

--- a/code/game/jobs/access_datum.dm
+++ b/code/game/jobs/access_datum.dm
@@ -80,7 +80,7 @@
 /datum/access/maint_tunnels
 	id = access_maint_tunnels
 	desc = "Maintenance"
-	region = ACCESS_REGION_ENGINEERING
+	region = ACCESS_REGION_GENERAL
 
 /var/const/access_external_airlocks = 13
 /datum/access/external_airlocks
@@ -97,7 +97,7 @@
 /var/const/access_change_ids = 15
 /datum/access/change_ids
 	id = access_change_ids
-	desc = "ID Computer"
+	desc = "Global Change IDs"
 	region = ACCESS_REGION_COMMAND
 
 /var/const/access_ai_upload = 16
@@ -226,21 +226,29 @@
 	desc = "Manufacturing"
 	access_type = ACCESS_TYPE_NONE
 
-// /var/const/free_access_id = 37
+/var/const/access_cmo = 37
+/datum/access/cmo
+	id = access_cmo
+	desc = "Chief Medical Officer"
+	region = ACCESS_REGION_COMMAND
 
-// /var/const/free_access_id = 38
-
-/var/const/access_virology = 39
+/var/const/access_virology = 38
 /datum/access/virology
 	id = access_virology
 	desc = "Virology"
 	region = ACCESS_REGION_MEDBAY
 
-/var/const/access_cmo = 40
-/datum/access/cmo
-	id = access_cmo
-	desc = "Chief Medical Officer"
-	region = ACCESS_REGION_COMMAND
+/var/const/access_change_medbay = 39
+/datum/access/change_medbay
+	id = access_change_medbay
+	desc = "Medbay Change IDs"
+	region = ACCESS_REGION_MEDBAY
+
+/var/const/access_change_engineering = 40
+/datum/access/change_engineering
+	id = access_change_engineering
+	desc = "Engineering Change IDs"
+	region = ACCESS_REGION_ENGINEERING
 
 /var/const/access_merchant = 41
 /datum/access/merchant
@@ -260,7 +268,11 @@
 	desc = "Theatre"
 	region = ACCESS_REGION_GENERAL
 
-// /var/const/free_access_id = 44
+/var/const/access_change_research = 44
+/datum/access/change_research
+	id = access_change_research
+	desc = "Research Change IDs"
+	region = ACCESS_REGION_RESEARCH
 
 /var/const/access_surgery = 45
 /datum/access/surgery
@@ -268,9 +280,17 @@
 	desc = "Surgery"
 	region = ACCESS_REGION_MEDBAY
 
-// /var/const/free_access_id = 46
+/var/const/access_change_cargo = 46
+/datum/access/change_cargo
+	id = access_change_cargo
+	desc = "Cargo Change IDs"
+	region = ACCESS_REGION_SUPPLY
 
-// /var/const/free_access_id = 47
+/var/const/access_change_nt = 47
+/datum/access/change_nt
+	id = access_change_nt
+	desc = "NT Change IDs"
+	region = ACCESS_REGION_CHURCH
 
 /var/const/access_mining = 48
 /datum/access/mining
@@ -290,7 +310,12 @@
 	desc = "Cargo Office"
 	region = ACCESS_REGION_SUPPLY
 
-// /var/const/free_access_id = 51
+/var/const/access_change_sec = 51
+/datum/access/change_sec
+	id = access_change_sec
+	desc = "Security Change IDs"
+	region = ACCESS_REGION_SECURITY
+
 // /var/const/free_access_id = 52
 
 /var/const/access_heads_vault = 53
@@ -389,7 +414,11 @@
 	desc = "Paramedic's Office"
 	region = ACCESS_REGION_MEDBAY
 
-// /var/const/free_access_id = 69
+/var/const/access_change_club = 69
+/datum/access/change_club
+	id = access_change_club
+	desc = "Club Change IDs"
+	region = ACCESS_REGION_GENERAL
 
 /**************
 * NeoTheology *
@@ -429,6 +458,8 @@
 	id = access_nt_inquisitor
 	desc = "Mekhane  Inquisitor"
 	region = ACCESS_REGION_CHURCH
+
+
 
 
 /******************

--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -16,7 +16,7 @@
 	)
 
 	access = list(
-		access_RC_announce, access_keycard_auth, access_heads, access_sec_doors, access_morgue, access_chapel_office, access_crematorium, access_hydroponics, access_janitor, access_maint_tunnels	//SYZYGY EDIT - transcribes preacher cruciform access onto their ID
+		access_RC_announce, access_keycard_auth, access_heads, access_sec_doors, access_morgue, access_chapel_office, access_crematorium, access_hydroponics, access_janitor, access_maint_tunnels, access_change_nt	//SYZYGY EDIT - transcribes preacher cruciform access onto their ID
 	)
 
 	wage = WAGE_PROFESSIONAL //The church has deep pockets

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -12,7 +12,8 @@
 	spawn_positions = 1
 	supervisors = "the Head of Personnel"
 	selection_color = "#dddddd"
-	access = list(access_bar, access_kitchen, access_maint_tunnels)
+	also_known_languages = list(LANGUAGE_CYRILLIC = 25, LANGUAGE_SERBIAN = 15, LANGUAGE_JIVE = 80)
+	access = list(access_bar, access_kitchen, access_maint_tunnels, access_change_club)
 	initial_balance = 3000
 	wage = WAGE_NONE // Makes his own money
 	stat_modifiers = list(

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -23,7 +23,7 @@
 		access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
 		access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
 		access_heads, access_construction, access_sec_doors,
-		access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload
+		access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload, access_change_engineering
 	)
 
 	stat_modifiers = list(

--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -14,7 +14,7 @@
 	access = list(
 		access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_merchant, access_mining,
 		access_heads, access_mining_station, access_RC_announce, access_keycard_auth, access_sec_doors,
-		access_eva, access_external_airlocks
+		access_eva, access_external_airlocks, access_change_cargo
 	)
 	ideal_character_age = 40
 	stat_modifiers = list(

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -19,7 +19,7 @@
 		access_moebius, access_medical_equip, access_morgue, access_genetics, access_heads,
 		access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 		access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_maint_tunnels,
-		access_external_airlocks, access_paramedic, access_research_equipment
+		access_external_airlocks, access_paramedic, access_research_equipment, access_change_medbay
 	)
 
 	ideal_character_age = 50

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -20,7 +20,8 @@
 		access_tox_storage, access_teleporter, access_sec_doors,
 		access_moebius, access_medical_equip, access_chemistry, access_virology, access_cmo, access_surgery, access_psychiatrist,
 		access_robotics, access_xenobiology, access_ai_upload, access_tech_storage, access_eva, access_external_airlocks,
-		access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network, access_research_equipment
+		access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network, access_research_equipment,
+		access_change_research
 	)
 	ideal_character_age = 50
 

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -22,7 +22,7 @@
 		access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
 		access_moebius, access_engine, access_mining, access_construction, access_mailsorting,
 		access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway,
-		access_external_airlocks
+		access_external_airlocks, access_change_sec
 	)
 
 	stat_modifiers = list(

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -404,7 +404,7 @@
 			return
 
 	if(!can_be_inserted(W))
-		return
+		return FALSE
 
 	if(istype(W, /obj/item/weapon/tray))
 		var/obj/item/weapon/tray/T = W

--- a/code/global.dm
+++ b/code/global.dm
@@ -6,8 +6,10 @@
 // Items that ask to be called every cycle.
 var/global/datum/datacore/data_core = null
 var/global/list/all_areas                = list()
-var/global/list/ship_areas                = list()
+var/global/list/ship_areas               = list()
 
+
+var/global/list/ships 	= list() // List of ships in the game.
 
 //var/global/list/machines                 = list()		//Removed
 //var/global/list/processing_objects       = list()		//Removed

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -10,7 +10,8 @@
 		return
 
 	for(var/obj/item/W in M)
-		M.drop_from_inventory(W)
+		if(W.is_equipped())
+			M.drop_from_inventory(W)
 
 	log_admin("[key_name(usr)] made [key_name(M)] drop everything!")
 	message_admins("[key_name_admin(usr)] made [key_name_admin(M)] drop everything!", 1)

--- a/code/modules/clothing/glasses/misc.dm
+++ b/code/modules/clothing/glasses/misc.dm
@@ -19,6 +19,7 @@
 	item_state = "glasses"
 	prescription = 1
 	body_parts_covered = 0
+	prescription = TRUE
 
 /obj/item/clothing/glasses/regular/scanners
 	name = "Scanning Goggles"

--- a/code/modules/mob/inventory/equip.dm
+++ b/code/modules/mob/inventory/equip.dm
@@ -126,15 +126,39 @@ var/list/slot_equipment_priority = list(
 			return backpack
 	return ..()
 /mob/living/carbon/human/proc/quick_equip_storage(obj/item/Item)
+	var/potential = src.get_inactive_hand()
 	if(istype(src.back,/obj/item/weapon/storage))
 		var/obj/item/weapon/storage/backpack = src.back
-		backpack.attackby(Item,src)
+		if(backpack.attackby(Item,src))
+			return TRUE
+	if(istype(potential, /obj/item/weapon/storage))
+		var/obj/item/weapon/storage/pack = potential
+		if(pack.attackby(Item,src))
+			return TRUE
+	if(quick_equip_belt(Item)) 
 		return TRUE
 	return FALSE
 /mob/living/carbon/human/proc/quick_equip_belt(obj/item/Item)
 	if(istype(src.belt,/obj/item/weapon/storage/))
 		var/obj/item/weapon/storage/B= src.belt
-		B.attackby(Item,src)
-		return TRUE
+		if(B.attackby(Item,src))
+			return TRUE
 	return FALSE
 
+/mob/living/carbon/human/proc/equip_to_from_suit_storage(obj/item/Item)
+	if(Item == src.s_store) 
+		if(put_in_active_hand(Item))
+			return TRUE
+	else
+		if(equip_to_slot_if_possible(Item, slot_s_store))
+			return TRUE
+
+/mob/living/carbon/human/proc/equip_to_from_bag(var/obj/item/Item, obj/item/weapon/storage/store)
+	if(Item)
+		store.attackby(Item,src)
+		return TRUE
+	else if(!Item && store.contents.len >=1) 
+		var/return_hand = hand ? slot_l_hand : slot_r_hand
+		equip_to_slot_if_possible(store.contents[store.contents.len], return_hand)
+		return TRUE
+	return FALSE

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -46,7 +46,7 @@
 	equipment_tint_total = 0
 	equipment_see_invis	= 0
 	equipment_vision_flags = 0
-	equipment_prescription = 0
+	equipment_prescription = FALSE
 	equipment_darkness_modifier = 0
 //	equipment_overlays.Cut()
 
@@ -59,8 +59,8 @@
 	if(istype(wearing_rig,/obj/item/weapon/rig))
 		process_rig(wearing_rig)
 
-/mob/living/carbon/human/proc/process_glasses(var/obj/item/clothing/glasses/G, var/forceActive)
-	if(G && (G.active || forceActive))
+/mob/living/carbon/human/proc/process_glasses(obj/item/clothing/glasses/G, var/forceactive)
+	if(G && (G.active || forceactive))
 		equipment_darkness_modifier += G.darkness_view
 		equipment_vision_flags |= G.vision_flags
 		equipment_prescription = equipment_prescription || G.prescription
@@ -84,7 +84,7 @@
 			equipment_tint_total += TINT_BLIND
 	var/obj/item/clothing/glasses/G = O.getCurrentGlasses()
 	if(G && O.visor.active)
-		process_glasses(G,1)
+		process_glasses(G,TRUE)
 
 /mob/living/carbon/human/reset_layer()
 	if(hiding)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -34,6 +34,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 	if(I)
 		if(src.s_store)
 			to_chat(src, SPAN_NOTICE("You have no room to equip or draw."))
+			return
 		else
 			equip_to_from_suit_storage(I)
 	else if ( src.s_store )

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -26,6 +26,42 @@ This saves us from having to call add_fingerprint() any time something is put in
 		return
 	if(quick_equip_belt(I))
 		return
+/mob/living/carbon/human/verb/suit_storage_equip()
+	set name = "suit-storage-equip"
+	set hidden = 1
+	
+	var/obj/item/I = get_active_hand()
+	if(I)
+		if(src.s_store)
+			to_chat(src, SPAN_NOTICE("You have no room to equip or draw."))
+		else
+			equip_to_from_suit_storage(I)
+	else if ( src.s_store )
+		equip_to_from_suit_storage(src.s_store)
+	else
+		to_chat(src, SPAN_NOTICE("You are not holding anything to equip or draw."))
+	return
+/mob/living/carbon/human/verb/bag_equip()
+	set name = "bag-equip"
+	set hidden = 1
+	
+	var/obj/item/I = get_active_hand()
+	var/potential = src.get_inactive_hand()
+	if(!I && !src.back)
+		to_chat(src, SPAN_NOTICE("You have no storage on your back or item in hand."))
+		return
+	if(istype(src.back,/obj/item/weapon/storage))
+		var/obj/item/weapon/storage/backpack = src.back
+		if(I)
+			equip_to_from_bag(I, backpack)
+		else
+			equip_to_from_bag(null, backpack)
+	else if(istype(potential, /obj/item/weapon/storage))
+		var/obj/item/weapon/storage/pack = potential
+		if(I)
+			equip_to_from_bag(I, pack)
+		else
+			equip_to_from_bag(null, pack)
 
 //Puts the item into our active hand if possible. returns 1 on success.
 /mob/living/carbon/human/put_in_active_hand(var/obj/item/W)

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -9,6 +9,15 @@
 	requires_ntnet = 0
 	size = 8
 
+	var/list/access_lookup = list(access_change_sec, 	//Lookup list for all the accesses that can use the ID computer.
+									access_change_medbay, 
+									access_change_research, 
+									access_change_engineering, 
+									access_change_ids, 
+									access_change_nt, 
+									access_change_cargo,
+									access_change_club)
+
 /datum/nano_module/program/card_mod
 	name = "ID card modification program"
 	var/mod_mode = 1
@@ -73,7 +82,7 @@
 			data["all_centcom_access"] = all_centcom_access
 		else
 			var/list/regions = list()
-			for(var/i = 1; i <= 7; i++)
+			for(var/i = ACCESS_REGION_MIN; i <= ACCESS_REGION_MAX; i++)
 				var/list/accesses = list()
 				for(var/access in get_region_accesses(i))
 					if (get_access_desc(access))
@@ -118,7 +127,8 @@
 	var/obj/item/weapon/card/id/id_card
 	if (computer.card_slot)
 		id_card = computer.card_slot.stored_card
-	if (!user_id_card)
+	if (!user_id_card || !authorized(user_id_card))
+		to_chat(user, SPAN_WARNING("Access denied"))
 		return
 
 	var/datum/nano_module/program/card_mod/module = NM
@@ -135,7 +145,7 @@
 				module.show_assignments = 1
 		if("print")
 			if(!authorized(user_id_card))
-				to_chat(usr, "<span class='warning'>Access denied.</span>")
+				to_chat(user, SPAN_WARNING("Access denied."))
 				return
 			if(computer && computer.printer) //This option should never be called if there is no printer
 				if(module.mod_mode)
@@ -158,20 +168,20 @@
 								contents += "  [get_access_desc(A)]"
 
 						if(!computer.printer.print_text(contents,"access report"))
-							to_chat(usr, "<span class='notice'>Hardware error: Printer was unable to print the file. It may be out of paper.</span>")
+							to_chat(user, SPAN_NOTICE("Hardware error: Printer was unable to print the file. It may be out of paper."))
 							return
 						else
-							computer.visible_message("<span class='notice'>\The [computer] prints out paper.</span>")
+							computer.visible_message(SPAN_NOTICE("\The [computer] prints out paper."))
 				else
 					var/contents = {"<h4>Crew Manifest</h4>
 									<br>
 									[html_crew_manifest()]
 									"}
 					if(!computer.printer.print_text(contents,text("crew manifest ([])", stationtime2text())))
-						to_chat(usr, "<span class='notice'>Hardware error: Printer was unable to print the file. It may be out of paper.</span>")
+						to_chat(user, SPAN_NOTICE("Hardware error: Printer was unable to print the file. It may be out of paper."))
 						return
 					else
-						computer.visible_message("<span class='notice'>\The [computer] prints out paper.</span>")
+						computer.visible_message(SPAN_NOTICE("\The [computer] prints out paper."))
 		if("eject")
 			if(computer)
 				if(computer.card_slot && computer.card_slot.stored_card)
@@ -179,8 +189,8 @@
 				else
 					computer.attackby(user.get_active_hand(), user)
 		if("terminate")
-			if(!authorized(user_id_card))
-				to_chat(usr, "<span class='warning'>Access denied.</span>")
+			if(!authorized(user_id_card, ACCESS_REGION_COMMAND))
+				to_chat(user, SPAN_WARNING("Access denied."))
 				return
 			if(computer && can_run(user, 1))
 				id_card.assignment = "Terminated"
@@ -188,7 +198,7 @@
 				callHook("terminate_employee", list(id_card))
 		if("edit")
 			if(!authorized(user_id_card))
-				to_chat(usr, "<span class='warning'>Access denied.</span>")
+				to_chat(user, SPAN_WARNING("Access denied."))
 				return
 			if(computer && can_run(user, 1))
 				if(href_list["name"])
@@ -198,7 +208,7 @@
 						id_card.formal_name_suffix = initial(id_card.formal_name_suffix)
 						id_card.formal_name_prefix = initial(id_card.formal_name_prefix)
 					else
-						computer.visible_message("<span class='notice'>[computer] buzzes rudely.</span>")
+						computer.visible_message(SPAN_NOTICE("[computer] buzzes rudely."))
 				else if(href_list["account"])
 					var/account_num = text2num(input("Enter account number.", "Account", id_card.associated_account_number))
 					id_card.associated_account_number = account_num
@@ -210,7 +220,7 @@
 					id_card.associated_email_login["password"] = email_password
 		if("assign")
 			if(!authorized(user_id_card))
-				to_chat(usr, "<span class='warning'>Access denied.</span>")
+				to_chat(user, SPAN_WARNING("Access denied."))
 				return
 			if(computer && can_run(user, 1) && id_card)
 				var/t1 = href_list["assign_target"]
@@ -231,10 +241,13 @@
 								jobdatum = J
 								break
 						if(!jobdatum)
-							to_chat(usr, "<span class='warning'>No log exists for this job: [t1]</span>")
+							to_chat(user, SPAN_WARNING("No log exists for this job: [t1]"))
 							return
-
 						access = jobdatum.get_access()
+						for(var/A in access)
+							if(!check_modify(user_id_card, A))
+								to_chat(user, SPAN_WARNING("Access denied"))
+								return
 
 					remove_nt_access(id_card)
 					apply_access(id_card, access)
@@ -247,13 +260,13 @@
 				var/access_type = text2num(href_list["access_target"])
 				var/access_allowed = text2num(href_list["allowed"])
 				if(access_type in get_access_ids(ACCESS_TYPE_STATION|ACCESS_TYPE_CENTCOM))
-					for(var/access in user_id_card.access)
-						var/region_type = get_access_region_by_id(access_type)
-						if(access in GLOB.maps_data.access_modify_region[region_type])
-							id_card.access -= access_type
-							if(!access_allowed)
-								id_card.access += access_type
-							break
+					if (check_modify(user_id_card, access_type))
+						id_card.access -= access_type
+						if(!access_allowed)
+							id_card.access += access_type
+					else
+						to_chat(user, SPAN_WARNING("Access denied"))
+
 	if(id_card)
 		id_card.SetName(text("[id_card.registered_name]'s ID Card ([id_card.assignment])"))
 
@@ -266,7 +279,21 @@
 /datum/computer_file/program/card_mod/proc/apply_access(var/obj/item/weapon/card/id/id_card, var/list/accesses)
 	id_card.access |= accesses
 
-/datum/computer_file/program/card_mod/proc/authorized(var/obj/item/weapon/card/id/id_card)
-	if (id_card)
-		return (access_change_ids in id_card.access)
+// Function that checks if the user's id is allowed to use the id computer. Can optionally check for a specific access lookup.
+/datum/computer_file/program/card_mod/proc/authorized(var/obj/item/weapon/card/id/id_card, var/area)
+	if (id_card && !area)
+		for(var/i = 1, i <= access_lookup.len, i ++)
+			if(access_lookup[i] in id_card.access)
+				return TRUE
+	else if (id_card && area)
+		if(access_lookup[area] in id_card.access)
+			return TRUE
+	return FALSE
+
+//New helper function to check if the type of access the user has matches the region it's allowed to change.
+/datum/computer_file/program/card_mod/proc/check_modify(var/obj/item/weapon/card/id/id_card, var/access_requested)
+	for(var/access in id_card.access)
+		var/region_type = get_access_region_by_id(access_requested)
+		if(access in GLOB.maps_data.access_modify_region[region_type])
+			return TRUE
 	return FALSE

--- a/code/modules/multiz/map_data.dm
+++ b/code/modules/multiz/map_data.dm
@@ -125,14 +125,21 @@ ADMIN_VERB_ADD(/client/proc/test_MD, R_DEBUG, null)
 	var/path = "eris"
 
 	var/access_modify_region = list(
-		ACCESS_REGION_SECURITY = list(access_hos, access_change_ids),
-		ACCESS_REGION_MEDBAY = list(access_cmo, access_change_ids),
-		ACCESS_REGION_RESEARCH = list(access_rd, access_change_ids),
-		ACCESS_REGION_ENGINEERING = list(access_ce, access_change_ids),
+		ACCESS_REGION_SECURITY = list(access_hos, access_change_ids, access_change_sec),
+		ACCESS_REGION_MEDBAY = list(access_cmo, access_change_ids, access_change_medbay),
+		ACCESS_REGION_RESEARCH = list(access_rd, access_change_ids, access_change_research),
+		ACCESS_REGION_ENGINEERING = list(access_ce, access_change_ids, access_change_engineering),
 		ACCESS_REGION_COMMAND = list(access_change_ids),
-		ACCESS_REGION_GENERAL = list(access_change_ids),
-		ACCESS_REGION_SUPPLY = list(access_change_ids),
-		ACCESS_REGION_CHURCH = list(access_nt_preacher, access_change_ids)
+		ACCESS_REGION_GENERAL = list(access_change_ids, 
+										access_change_cargo, 
+										access_change_club, 
+										access_change_engineering, 
+										access_change_medbay, 
+										access_change_nt,
+										access_change_research,
+										access_change_sec),
+		ACCESS_REGION_SUPPLY = list(access_change_ids, access_change_cargo),
+		ACCESS_REGION_CHURCH = list(access_nt_preacher, access_change_ids, access_change_nt)
 	)
 
 	//HOLOMAP

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -17,6 +17,9 @@
 	var/known = 1		//shows up on nav computers automatically
 	var/in_space = 1	//can be accessed via lucky EVA
 
+	var/global/eris_start_set = FALSE //Tells us if we need to modify a random location for Eris to start at
+	var/global/eris
+
 /obj/effect/overmap/Initialize()
 	. = ..()
 
@@ -27,8 +30,16 @@
 	for(var/zlevel in map_z)
 		map_sectors["[zlevel]"] = src
 
+	// Spawning location of area is randomized or default values, but can be changed to the Eris Coordinates in the code below.
+	// This provides a random starting location for Eris.
 	start_x = start_x || rand(OVERMAP_EDGE, GLOB.maps_data.overmap_size - OVERMAP_EDGE)
 	start_y = start_y || rand(OVERMAP_EDGE, GLOB.maps_data.overmap_size - OVERMAP_EDGE)
+
+	if ((!eris_start_set) && (name == config.start_location))
+		var/obj/effect/overmap/ship/eris/E = ships[eris]
+		start_x = E.start_x
+		start_y = E.start_y
+		eris_start_set = TRUE
 
 	forceMove(locate(start_x, start_y, GLOB.maps_data.overmap_z))
 	testing("Located sector \"[name]\" at [start_x],[start_y], containing Z [english_list(map_z)]")

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -368,15 +368,16 @@
 
 // examine verb
 /obj/machinery/light/examine(mob/user)
+	..()
 	switch(status)
 		if(LIGHT_OK)
-			to_chat(user, "[desc] It is turned [on? "on" : "off"].")
+			to_chat(user, "It is turned [on? "on" : "off"].")
 		if(LIGHT_EMPTY)
-			to_chat(user, "[desc] The [fitting] has been removed.")
+			to_chat(user, "The [fitting] has been removed.")
 		if(LIGHT_BURNED)
-			to_chat(user, "[desc] The [fitting] is burnt out.")
+			to_chat(user, "The [fitting] is burnt out.")
 		if(LIGHT_BROKEN)
-			to_chat(user, "[desc] The [fitting] has been smashed.")
+			to_chat(user, "The [fitting] has been smashed.")
 
 
 
@@ -394,15 +395,22 @@
 
 	// attempt to insert light
 	if(istype(I, /obj/item/weapon/light))
-		if(status != LIGHT_EMPTY)
-			to_chat(user, "There is a [fitting] already inserted.")
+		if(status == LIGHT_OK)
+			to_chat(user, SPAN_WARNING("There is a [fitting] already inserted."))
 			return
 		else
 			src.add_fingerprint(user)
 			var/obj/item/weapon/light/L = I
 			if(istype(L, light_type))
+				user.drop_item()
+
+				if(status != LIGHT_EMPTY)
+					drop_light_tube(user)
+					to_chat(user, SPAN_NOTICE("You replace [L]."))
+				else
+					to_chat(user, SPAN_NOTICE("You insert [L]."))
+
 				status = L.status
-				to_chat(user, "You insert the [L.name].")
 				switchcount = L.switchcount
 				rigged = L.rigged
 				brightness_range = L.brightness_range
@@ -411,17 +419,15 @@
 				on = has_power()
 				update()
 
-				user.drop_item()	//drop the item to update overlays and such
 				qdel(L)
 
 				if(on && rigged)
-
 					log_admin("LOG: Rigged light explosion, last touched by [fingerprintslast]")
 					message_admins("LOG: Rigged light explosion, last touched by [fingerprintslast]")
 
 					explode()
 			else
-				to_chat(user, "This type of light requires a [fitting].")
+				to_chat(user, SPAN_WARNING("This type of light requires a [fitting]."))
 				return
 
 		// attempt to break the light
@@ -531,49 +537,31 @@
 
 	// make it burn hands if not wearing fire-insulated gloves
 	if(on)
-		var/prot = 0
+		var/prot = FALSE
 		var/mob/living/carbon/human/H = user
 
 		if(istype(H))
 			if(H.species.heat_level_1 > LIGHT_BULB_TEMPERATURE)
-				prot = 1
+				prot = TRUE
 			else if(H.gloves)
 				var/obj/item/clothing/gloves/G = H.gloves
 				if(G.max_heat_protection_temperature)
 					if(G.max_heat_protection_temperature > LIGHT_BULB_TEMPERATURE)
-						prot = 1
+						prot = TRUE
 		else
-			prot = 1
+			prot = TRUE
 
-		if(prot > 0 || (COLD_RESISTANCE in user.mutations))
-			to_chat(user, "You remove the light [fitting]")
+		if(prot || (COLD_RESISTANCE in user.mutations))
+			to_chat(user, SPAN_NOTICE("You remove the light [fitting]"))
 		else if(TK in user.mutations)
-			to_chat(user, "You telekinetically remove the light [fitting].")
+			to_chat(user, SPAN_NOTICE("You telekinetically remove the light [fitting]."))
 		else
 			to_chat(user, "You try to remove the light [fitting], but it's too hot and you don't want to burn your hand.")
 			return				// if burned, don't remove the light
 	else
-		to_chat(user, "You remove the light [fitting].")
+		to_chat(user, SPAN_NOTICE("You remove the light [fitting]."))
 
-	// create a light tube/bulb item and put it in the user's hand
-	var/obj/item/weapon/light/L = new light_type()
-	L.status = status
-	L.rigged = rigged
-	L.brightness_range = brightness_range
-	L.brightness_power = brightness_power
-	L.brightness_color = brightness_color
-
-	// light item inherits the switchcount, then zero it
-	L.switchcount = switchcount
-	switchcount = 0
-
-	L.update()
-	L.add_fingerprint(user)
-
-	user.put_in_active_hand(L)	//puts it in our active hand
-
-	status = LIGHT_EMPTY
-	update()
+	drop_light_tube(user)
 
 
 /obj/machinery/light/attack_tk(mob/user)
@@ -581,9 +569,13 @@
 		to_chat(user, "There is no [fitting] in this light.")
 		return
 
-	to_chat(user, "You telekinetically remove the light [fitting].")
-	// create a light tube/bulb item and put it in the user's hand
-	var/obj/item/weapon/light/L = new light_type()
+	to_chat(user, SPAN_NOTICE("You telekinetically remove the light [fitting]."))
+	drop_light_tube()
+
+
+// create a light tube/bulb item and put it in the drop location
+/obj/machinery/light/proc/drop_light_tube(mob/living/user)
+	var/obj/item/weapon/light/L = new light_type(drop_location())
 	L.status = status
 	L.rigged = rigged
 	L.brightness_range = brightness_range
@@ -595,11 +587,15 @@
 	switchcount = 0
 
 	L.update()
-	L.add_fingerprint(user)
-	L.loc = loc
 
 	status = LIGHT_EMPTY
 	update()
+
+	// If the target is a mob, try to put the bulb in mob's hand
+	if(user)
+		L.add_fingerprint(user)
+		user.put_in_active_hand(L)
+
 
 // break the light and make sparks if was on
 
@@ -767,7 +763,7 @@
 	if(istype(I, /obj/item/weapon/reagent_containers/syringe))
 		var/obj/item/weapon/reagent_containers/syringe/S = I
 
-		to_chat(user, "You inject the solution into the [src].")
+		to_chat(user, "You inject the solution into [src].")
 
 		if(S.reagents.has_reagent("phoron", 5))
 

--- a/code/modules/trade/datums/trade_stations_presets/zarya.dm
+++ b/code/modules/trade/datums/trade_stations_presets/zarya.dm
@@ -36,7 +36,8 @@
 			/obj/item/clothing/head/welding,
 			/obj/item/weapon/tool/omnitool,
 			/obj/structure/reagent_dispensers/fueltank,
-			/obj/machinery/floodlight
+			/obj/machinery/floodlight,
+			/obj/spawner/lathe_disk
 		)
 	)
 

--- a/code/modules/trade/datums/trade_stations_presets/zarya.dm
+++ b/code/modules/trade/datums/trade_stations_presets/zarya.dm
@@ -36,8 +36,7 @@
 			/obj/item/clothing/head/welding,
 			/obj/item/weapon/tool/omnitool,
 			/obj/structure/reagent_dispensers/fueltank,
-			/obj/machinery/floodlight,
-			/obj/spawner/lathe_disk
+			/obj/machinery/floodlight
 		)
 	)
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -348,3 +348,9 @@ IPR_MINIMUM_AGE 5
 
 # Enable/disable 'panic bunker' (prevents new players from joining if they've never been seen before in the DB)
 #PANIC_BUNKER
+
+# Set start location for CEV Eris uncomment ONE only.
+RANDOM_START
+#ASTEROID_START
+#FORTRESS_START
+#RUINS_START

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -68,6 +68,8 @@ Hotkey-Mode: (hotkey-mode must be on)
 \tq = drop
 \te = equip
 \tShift+e = belt-equip
+\tShift+q = suit-storage-equip
+\tShift+b = bag-equip
 \tr = throw
 \tt = say
 \t5 = emote

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -567,6 +567,12 @@ macro "hotkeymode"
 	elem
 		name = "SHIFT+E"
 		command = "belt-equip"
+	elem 
+		name = "SHIFT+Q"
+		command = "suit-storage-equip"
+	elem 
+		name = "SHIFT+B"
+		command = "bag-equip"
 	elem  
 		name = "CTRL+E"
 		command = "quick-equip"

--- a/maps/CEVEris/overmap-eris.dm
+++ b/maps/CEVEris/overmap-eris.dm
@@ -43,6 +43,11 @@
 		"nav_bridge_aquila"
 	)*/
 
+/obj/effect/overmap/ship/eris/Initialize()
+	.=..()
+	if(name == "CEV Eris")
+		ships[eris] = src
+
 /obj/machinery/computer/shuttle_control/explore/exploration_shuttle
 	name = "shuttle control console"
 	shuttle_tag = "Vasiliy Dokuchaev"

--- a/maps/CEVEris/overmap-eris.dm
+++ b/maps/CEVEris/overmap-eris.dm
@@ -45,7 +45,7 @@
 
 /obj/effect/overmap/ship/eris/Initialize()
 	.=..()
-	if(name == "CEV Eris")
+	if(name == "NEV Northern Light")	//Syzygy edit - to make this work with our ship name
 		ships[eris] = src
 
 /obj/machinery/computer/shuttle_control/explore/exploration_shuttle

--- a/maps/encounters/asteroid/asteroid.dm
+++ b/maps/encounters/asteroid/asteroid.dm
@@ -9,8 +9,6 @@
 		"nav_asteroid_1",
 		"nav_asteroid_2"
 	)
-	start_x = 9
-	start_y = 10
 	known = 1
 	in_space = 0
 


### PR DESCRIPTION
## About The Pull Request

This PR cherry picks the following PRs:
https://github.com/discordia-space/CEV-Eris/pull/5505
https://github.com/discordia-space/CEV-Eris/pull/5558
https://github.com/discordia-space/CEV-Eris/pull/5561
https://github.com/discordia-space/CEV-Eris/pull/5563
https://github.com/discordia-space/CEV-Eris/pull/5565
https://github.com/discordia-space/CEV-Eris/pull/5571
https://github.com/discordia-space/CEV-Eris/pull/5572

This should notably make the E hotkey less prone to bagging everything. Hopefully.

Also, all heads can now modify IDs with access for their specific department now.

EDIT: The ship now has a random starting position at the start of the round. It can start at the mining asteroids, space ruins, or space fortress.

**This requires a config change.**

```
# Set start location for CEV Eris uncomment ONE only.
RANDOM_START
#ASTEROID_START
#FORTRESS_START
#RUINS_START
```

The above should be appended to the end of config.txt

## Changelog
```changelog CEV-Eris Developers
add: Heads can now modify IDs with access for their department.
fix: Hopefully fixed the E hotkey bagging all your items instead of properly stowing them away
add: Eris will now randomly start at 1 of 3 locations.
add: Lines in config file to determine starting location.
del: Asteroid loses its default location.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
