### PR TITLE
Hotfix for CMO and Virology access being messed up

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -69970,22 +69970,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/turret_protected/ai)
-"dik" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command{
-	name = "Moebius Biolab Officer's Quarters";
-	req_access = list(40)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel/cargo,
-/area/eris/command/mbo/quarters)
 "dil" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -103286,6 +103270,22 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
+"eYN" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/command{
+	name = "Moebius Biolab Officer's Quarters";
+	req_access = list(37)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel/cargo,
+/area/eris/command/mbo/quarters)
 "eZV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/steel,
@@ -245041,7 +245041,7 @@ dbF
 cWD
 cwZ
 cCS
-dik
+eYN
 dkX
 dly
 dma

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -23477,18 +23477,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/eris/maintenance/section1deck4central)
-"bdj" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = 24;
-	req_access = list(39)
-	},
-/obj/machinery/smartfridge/secure/virology,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/eris/medical/virology)
 "bdk" = (
 /obj/item/weapon/contraband/poster,
 /obj/item/weapon/contraband/poster,
@@ -25816,24 +25804,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/virology)
-"biP" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = -24;
-	req_access = list(39)
-	},
-/turf/simulated/floor/tiled/dark,
-/area/eris/hallway/side/morguehallway)
 "biQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -27580,23 +27550,6 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
 /area/eris/security/evidencestorage)
-"bmu" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 1
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = -24;
-	req_access = list(39)
-	},
-/turf/simulated/floor/tiled/white/panels,
-/area/eris/medical/virology)
 "bmv" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white/panels,
@@ -28102,20 +28055,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
-"bnv" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = 24;
-	req_access = list(39)
-	},
-/turf/simulated/floor/tiled/white/panels,
-/area/eris/medical/virology)
 "bnw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30655,30 +30594,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
-"btN" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/medical{
-	autoclose = 0;
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "virology_airlock_interior";
-	locked = 1;
-	name = "Virology Interior Airlock";
-	req_access = list(39)
-	},
-/turf/simulated/floor/tiled/white/cargo,
-/area/eris/medical/virology)
 "btO" = (
 /obj/structure/catwalk,
 /obj/random/junk/low_chance,
@@ -30749,30 +30664,6 @@
 "btX" = (
 /turf/simulated/open,
 /area/eris/maintenance/section1deck3central)
-"btY" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/medical{
-	autoclose = 0;
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "virology_airlock_exterior";
-	locked = 1;
-	name = "Virology Exterior Airlock";
-	req_access = list(39)
-	},
-/turf/simulated/floor/tiled/white/cargo,
-/area/eris/medical/virology)
 "btZ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -46201,14 +46092,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section1)
-"cdp" = (
-/obj/machinery/door/airlock/glass_command{
-	name = "Moebius Biolab Officer";
-	req_access = list(40)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white/cargo,
-/area/eris/command/mbo)
 "cdq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_common{
@@ -71483,30 +71366,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
-"dlj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "MedbayTotalLockdown";
-	layer = 2.6;
-	name = "Medbay Total Lockdown";
-	opacity = 0
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance_medical{
-	name = "MBO Maintenance";
-	req_access = list(40)
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/techmaint_cargo,
-/area/eris/command/mbo)
 "dlk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -103521,6 +103380,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/construction)
+"gFu" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = 24;
+	req_access = list(38)
+	},
+/turf/simulated/floor/tiled/white/panels,
+/area/eris/medical/virology)
 "gGt" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -103692,6 +103565,18 @@
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/engineering/post)
+"iSq" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = 24;
+	req_access = list(38)
+	},
+/obj/machinery/smartfridge/secure/virology,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/eris/medical/virology)
 "iUs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 9
@@ -103736,6 +103621,24 @@
 /obj/effect/shuttle_landmark/merc/mining,
 /turf/space,
 /area/space)
+"jqq" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -24;
+	req_access = list(38)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eris/hallway/side/morguehallway)
 "jtf" = (
 /obj/structure/table/standard,
 /obj/machinery/chem_heater,
@@ -103886,6 +103789,30 @@
 /obj/item/weapon/cell/small/high,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/command/bridge)
+"kCh" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical{
+	autoclose = 0;
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "virology_airlock_exterior";
+	locked = 1;
+	name = "Virology Exterior Airlock";
+	req_access = list(38)
+	},
+/turf/simulated/floor/tiled/white/cargo,
+/area/eris/medical/virology)
 "kCR" = (
 /obj/structure/table/standard,
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo,
@@ -104162,6 +104089,30 @@
 	},
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/medical/surgery)
+"mTY" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical{
+	autoclose = 0;
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "virology_airlock_interior";
+	locked = 1;
+	name = "Virology Interior Airlock";
+	req_access = list(38)
+	},
+/turf/simulated/floor/tiled/white/cargo,
+/area/eris/medical/virology)
 "mVq" = (
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/maintenance/section2deck1port)
@@ -104425,6 +104376,14 @@
 /obj/item/weapon/storage/freezer/medical,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/surgery)
+"oYt" = (
+/obj/machinery/door/airlock/glass_command{
+	name = "Moebius Biolab Officer";
+	req_access = list(37)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white/cargo,
+/area/eris/command/mbo)
 "paj" = (
 /obj/structure/sign/faction/moebius{
 	pixel_y = -32
@@ -104643,6 +104602,30 @@
 /obj/effect/shuttle_landmark/merc/sec2east,
 /turf/space,
 /area/space)
+"sHC" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "MedbayTotalLockdown";
+	layer = 2.6;
+	name = "Medbay Total Lockdown";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance_medical{
+	name = "MBO Maintenance";
+	req_access = list(37)
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techmaint_cargo,
+/area/eris/command/mbo)
 "sJL" = (
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/reinforced,
@@ -105054,6 +105037,23 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/chemistry)
+"wIp" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -24;
+	req_access = list(38)
+	},
+/turf/simulated/floor/tiled/white/panels,
+/area/eris/medical/virology)
 "wMa" = (
 /obj/structure/closet/crate/radiation,
 /obj/structure/railing/grey{
@@ -162243,7 +162243,7 @@ aWS
 bsB
 biO
 bll
-bdj
+iSq
 bmx
 bkW
 bkW
@@ -162444,7 +162444,7 @@ bhL
 bhL
 bhL
 bhL
-btN
+mTY
 bhL
 bmx
 blC
@@ -162647,7 +162647,7 @@ bfp
 bhL
 aXL
 aYw
-bmu
+wIp
 bmx
 bls
 bnV
@@ -163051,7 +163051,7 @@ bfp
 bhL
 aXP
 aZz
-bnv
+gFu
 bmx
 bnU
 bpp
@@ -163252,7 +163252,7 @@ auG
 auG
 bhL
 bhL
-btY
+kCh
 bhL
 bmx
 bnl
@@ -163455,7 +163455,7 @@ bgo
 bcH
 bdy
 beA
-biP
+jqq
 biZ
 bjt
 bkr
@@ -204249,7 +204249,7 @@ abF
 cvS
 cvS
 chl
-cdp
+oYt
 chl
 coC
 cqV
@@ -245264,7 +245264,7 @@ dzH
 dzH
 dzZ
 dAi
-dlj
+sHC
 dzM
 dzO
 dte
@@ -245459,7 +245459,7 @@ aaa
 aaa
 chl
 dxw
-cdp
+oYt
 dzu
 dzI
 dzP


### PR DESCRIPTION
## About The Pull Request
Now virology is not CMO-only, and the CMO's office and quarters will no longer require CE access to open.

## Changelog
```changelog
fix: CMO and virology airlock access has been fixed
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
