### PR TITLE
Hotfix: Non-hotkeymode will now be playable

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -84,6 +84,7 @@ Hotkey-Mode: (hotkey-mode must be on)
 \t4 = harm-intent
 \tCtrl = drag
 \tShift = examine
+\tm = multiline input menu for emotes
 </font>"}
 
 	var/other = {"<font color='purple'>
@@ -113,7 +114,7 @@ Any-Mode: (hotkey doesn't need to be on)
 \tPGUP = swap-hand
 \tPGDN = activate held object
 \tEND = throw
-\tm = multiline input menu for emotes
+\tCtrl+F4 = multiline input menu for emotes
 </font>"}
 
 	var/robot_hotkey_mode = {"<font color='purple'>

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -353,9 +353,6 @@ macro "macro"
 		name = "CTRL+SHIFT+G"
 		command = ".configure graphics-hwmode on"
 	elem 
-		name = "M"
-		command = "me-multiline-verb"
-	elem 
 		name = "CTRL+Q"
 		command = ".northwest"
 	elem 
@@ -424,6 +421,9 @@ macro "macro"
 	elem 
 		name = "F4"
 		command = "me-verb"
+	elem 
+		name = "CTRL+F4"
+		command = "me-multiline-verb"
 	elem 
 		name = "F5"
 		command = "asay"
@@ -696,6 +696,9 @@ macro "hotkeymode"
 	elem 
 		name = "F4"
 		command = "me-verb"
+	elem 
+		name = "CTRL+F4"
+		command = "me-multiline-verb"
 	elem 
 		name = "F5"
 		command = "asay"


### PR DESCRIPTION
## About The Pull Request

I had mistakenly made M activate multiline Me even in non-hotkey mode. This has obvious ramifications. It is now fixed, and ctrl+F4 now works as an alternate universal activation method.

## Changelog
```changelog Toriate
fix: non-hotkeymode is now playable
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
