### PR TITLE
Fixes not being able to implant implants in core implanted people with implanters.

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/excelsior.dm
+++ b/code/game/objects/items/weapons/implant/implants/excelsior.dm
@@ -58,8 +58,8 @@
 	//This is handled seperately to account for the future possibility of non-humans having cruciforms. Like holy dogs!
 	if (is_neotheology_disciple(target))
 		//Cruciform blocks other implants
-		return FALSE
-
+		return TRUE
+//Szy Edit. Yeah, right. You thought you were safe?
 
 	//Thirdly an organic check. No implanting robots
 	//Any other organic creature is fine. This allows you to implant your pets so the turrets dont shoot them

--- a/code/modules/core_implant/core_implant.dm
+++ b/code/modules/core_implant/core_implant.dm
@@ -167,7 +167,7 @@
 		return FALSE
 
 	if(!CM.can_install(src))
-		return FALSE
+		return TRUE
 
 	if(CM.unique)
 		for(var/datum/core_module/EM in modules)

--- a/code/modules/core_implant/core_implant.dm
+++ b/code/modules/core_implant/core_implant.dm
@@ -167,7 +167,7 @@
 		return FALSE
 
 	if(!CM.can_install(src))
-		return TRUE
+		return TRUE //Szy edit. Now you can actually implant yourself.
 
 	if(CM.unique)
 		for(var/datum/core_module/EM in modules)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pretty much does what it says on the tin. Core implants and being part of the church no longer preclude you from having implants of any type.. 

## Why It's Good For The Game

Makes our code a little more consistent with how the lore seems to be going insofar as the church espousing that we're all just brains piloting meat mechs and we should be allowed to change them to suit our whims. This just takes it a step further with allowing implants.

## Changelog
```Changelog
tweak: Core implants no longer prevent you from having additional implants. Death alarms for our custodians, weee.