### PR TITLE
Loads more blacklisting

### DIFF
--- a/zzz_modular_syzygy/code/modules/loot_spawn_blacklist.dm
+++ b/zzz_modular_syzygy/code/modules/loot_spawn_blacklist.dm
@@ -74,13 +74,22 @@
 	spawn_blacklisted = TRUE //Excelsior .30 AKMS
 
 /obj/item/weapon/cell/large/moebius/hyper
-	spawn_blacklisted = TRUE //"Power-Geyser 18000L"
+	rarity_value = 32 //"Power-Geyser 18000L"
+
+/obj/item/weapon/cell/large/hyper
+	rarity_value = 40 // "Robustcell-X 20000L
+
+/obj/item/weapon/cell/medium/hyper
+	rarity_value = 38 // "Robustcell-X 1500M"
 
 /obj/item/weapon/cell/medium/moebius/hyper
-	spawn_blacklisted = TRUE //"Power-Geyser 1300M"
+	rarity_value = 30 // "Power-Geyser 1300M"
+
+/obj/item/weapon/cell/small/hyper
+	rarity_value = 32 // "Robustcell-X 500S"
 
 /obj/item/weapon/cell/small/moebius/hyper
-	spawn_blacklisted = TRUE //"Power-Geyser 400S"
+	rarity_value = 28 // "Power-Geyser 400S"
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/advanced/shady
 	spawn_blacklisted = TRUE //"warez"

--- a/zzz_modular_syzygy/code/modules/loot_spawn_blacklist.dm
+++ b/zzz_modular_syzygy/code/modules/loot_spawn_blacklist.dm
@@ -27,3 +27,97 @@
 //Context = This is from a rig module
 /obj/item/weapon/tank/jetpack/rig
 	spawn_blacklisted = TRUE //"maneuvring jets"
+
+/obj/item/weapon/gun/energy/lasercannon
+	spawn_blacklisted = TRUE //Prototype: laser cannon
+
+/obj/item/weapon/gun/energy/captain
+	spawn_blacklisted = TRUE //NT LG \"Destiny\"
+
+/obj/item/weapon/gun/energy/decloner
+	spawn_blacklisted = TRUE //decloner
+
+/obj/item/weapon/gun/projectile/automatic/c20r
+	spawn_blacklisted = TRUE //"C-20r"
+
+/obj/item/weapon/gun/energy/plasma/brigador
+	spawn_blacklisted = TRUE //NanoTrasen PP \"Brigador\"
+
+/obj/item/weapon/gun/energy/plasma/martyr
+	spawn_blacklisted = TRUE //NT PR \"Martyr\"
+
+/obj/item/weapon/gun/energy/temperature
+	spawn_blacklisted = TRUE //temp gun
+
+/obj/item/weapon/gun/energy/floragun
+	spawn_blacklisted = TRUE //plant gun
+
+/obj/item/weapon/gun/projectile/automatic/vector
+	spawn_blacklisted = TRUE //"VK-00b"
+
+/obj/item/weapon/gun/matter/launcher/reclaimer
+	spawn_blacklisted = TRUE //exl reclaimer
+
+/obj/item/weapon/gun/matter/launcher/nt_sprayer
+	spawn_blacklisted = TRUE //NT BCR \"Street Sprayer\"
+
+/obj/item/weapon/gun/projectile/automatic/vintorez
+	spawn_blacklisted = TRUE //Excelsior .20 \"Vintorez\"
+
+/obj/item/weapon/gun/projectile/automatic/drozd
+	spawn_blacklisted = TRUE //Excelsior SMG .40 Magnum \"Drozd\"
+
+/obj/item/weapon/gun/projectile/clarissa/makarov
+	spawn_blacklisted = TRUE //Excelsior .35 Auto \"Makarov\"
+
+/obj/item/weapon/gun/projectile/automatic/ak47
+	spawn_blacklisted = TRUE //Excelsior .30 AKMS
+
+/obj/item/weapon/cell/large/moebius/hyper
+	spawn_blacklisted = TRUE //"Power-Geyser 18000L"
+
+/obj/item/weapon/cell/medium/moebius/hyper
+	spawn_blacklisted = TRUE //"Power-Geyser 1300M"
+
+/obj/item/weapon/cell/small/moebius/hyper
+	spawn_blacklisted = TRUE //"Power-Geyser 400S"
+
+/obj/item/weapon/computer_hardware/hard_drive/portable/advanced/shady
+	spawn_blacklisted = TRUE //"warez"
+
+/obj/item/weapon/computer_hardware/hard_drive/portable/advanced/nuke
+	spawn_blacklisted = TRUE //"nuke"
+
+/obj/item/weapon/gun/projectile/heavysniper
+	spawn_blacklisted = TRUE //SA AMR \"Hristov\"
+
+/obj/item/weapon/gun/projectile/rpg
+	spawn_blacklisted = TRUE //RPG-7
+
+/obj/item/weapon/storage/deferred/crate/saw
+	spawn_blacklisted = TRUE //infantry support crate
+
+/obj/item/weapon/storage/deferred/crate/ak
+	spawn_blacklisted = TRUE //rifleman crate
+
+/obj/item/weapon/storage/deferred/crate/grenadier
+	spawn_blacklisted = TRUE //demolitions crate
+
+/obj/item/weapon/storage/deferred/crate/antiarmor
+	spawn_blacklisted = TRUE //grenadier crate
+
+/obj/item/weapon/storage/deferred/crate/demolition
+	spawn_blacklisted = TRUE //breaching  crate
+
+/obj/item/weapon/storage/deferred/crate/marksman
+	spawn_blacklisted = TRUE //marksman crate
+
+/obj/item/weapon/storage/deferred/crate/sidearm
+	spawn_blacklisted = TRUE //sidearm crate
+
+/obj/item/weapon/storage/deferred/crate/specialists_sidearm
+	spawn_blacklisted = TRUE //specialists sidearm crate
+
+/obj/item/weapon/storage/deferred/crate/sidearm
+	spawn_blacklisted = TRUE //grenadier crate
+


### PR DESCRIPTION
## About The Pull Request

Most of RnD guns are now RnD only.
RPG and Exl guns are now will not spawn if they did at all
Both Reclamer and the Cleaning sudd gun thing will not spawn if they did at all
hyper cells are now much rarer as well as the XL line
Both nuke disk and warez disk are now strange console only
most deferred crates will now not spawn if they did at all
AMR will no longer spawn randomly if it did at all
captain gun will no longer spawn in maints if they did at all

## Why It's Good For The Game

Preventing OP/bad things from spawning is good

## Changelog
```changelog
balance: Most of RnD guns are now RnD only.
balance: RPG and Exl guns are now blacklisted
balance: Both Reclamer and the Cleaning sudd gun thing
balance: hyper cells are now much rarer as well as the XL line
balance: Both nuke disk and warez disk are now strange console only
balance: most deferred crates will now not spawn if they did at all
balance: AMR will no longer spawn randomly if it did at all
balance: captain gun will no longer spawn in maints if they did at all
```
