### PR TITLE
Gun Tagging Fix

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -109,7 +109,7 @@
 		item_icons = item_icons_cache[type]
 	if(one_hand_penalty || twohanded && (!wielded_item_state))//If the gun has a one handed penalty or is twohanded, but has no wielded item state then use this generic one.
 		wielded_item_state = "_doble" //Someone mispelled double but they did it so consistently it's staying this way.
-
+	generate_guntags()
 	var/obj/screen/item_action/action = new /obj/screen/item_action/top_bar/weapon_info
 	action.owner = src
 	hud_actions += action

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -27,7 +27,6 @@
 	var/use_external_power = FALSE	//if set, the weapon will look for an external power source to draw from, otherwise it recharges magically
 	var/recharge_time = 4
 	var/charge_tick = 0
-	gun_tags = list(GUN_ENERGY)
 	var/overcharge_timer //Holds ref to the timer used for overcharging
 	var/overcharge_rate = 1 //Base overcharge additive rate for the gun
 	var/overcharge_level = 0 //What our current overcharge level is. Peaks at overcharge_max
@@ -164,3 +163,9 @@
 	overcharge_max = initial(overcharge_max)
 	overcharge_rate = initial(overcharge_rate)
 	..()
+
+/obj/item/weapon/gun/energy/generate_guntags()
+	..()
+	gun_tags |= GUN_ENERGY
+	if(istype(projectile_type, /obj/item/projectile/beam))
+		gun_tags |= GUN_LASER

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -14,7 +14,6 @@
 	price_tag = 2500
 	rarity_value = 12
 	projectile_type = /obj/item/projectile/beam/midlaser
-	gun_tags = list(GUN_LASER)
 	init_firemodes = list(
 		WEAPON_NORMAL,
 		WEAPON_CHARGE

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -40,7 +40,6 @@
 	var/auto_eject_sound
 	var/ammo_mag = "default" // magazines + gun itself. if set to default, then not used
 	var/tac_reloads = TRUE	// Enables guns to eject mag and insert new magazine.
-	gun_tags = list(GUN_PROJECTILE)
 
 /obj/item/weapon/gun/projectile/Destroy()
 	QDEL_NULL(chambered)

--- a/code/modules/projectiles/guns/projectile/automatic/atreides.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/atreides.dm
@@ -21,7 +21,7 @@
 	damage_multiplier = 0.8
 	recoil_buildup = 4
 	one_hand_penalty = 5 //smg level
-	gun_tags = list(GUN_PROJECTILE, GUN_SILENCABLE)
+	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
 		FULL_AUTO_400,

--- a/code/modules/projectiles/guns/projectile/automatic/c20r.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/c20r.dm
@@ -29,7 +29,7 @@
 	one_hand_penalty = 5 //smg level
 	rarity_value = 19.2
 
-	gun_tags = list(GUN_PROJECTILE,GUN_SILENCABLE)
+	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
 		FULL_AUTO_400,

--- a/code/modules/projectiles/guns/projectile/automatic/drozd.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/drozd.dm
@@ -18,10 +18,10 @@
 	damage_multiplier = 0.8 	 //25,6 lethal, 28 HV //damage
 	penetration_multiplier = 1.5 //22.5 lethal, 30 HV //AP
 	recoil_buildup = 6
-	
+
 	twohanded = FALSE
 	one_hand_penalty = 5 //smg level
-	gun_tags = list(GUN_PROJECTILE, GUN_SILENCABLE)
+	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
 		FULL_AUTO_300,

--- a/code/modules/projectiles/guns/projectile/automatic/maxim.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/maxim.dm
@@ -23,7 +23,6 @@
 	fire_sound = 'sound/weapons/guns/fire/lmg_fire.ogg'
 	recoil_buildup = 3
 	one_hand_penalty = 30 //not like it's used anyway, but LMG level
-	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG)
 	init_firemodes = list(
 		FULL_AUTO_600,
 		list(mode_name="short bursts", burst=5,    burst_delay=1, move_delay=6,  icon="burst"),

--- a/code/modules/projectiles/guns/projectile/automatic/molly.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/molly.dm
@@ -22,7 +22,7 @@
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 
 	damage_multiplier = 0.7 //good for rubber takedowns or self-defence, not so good to kill someone, you might want to use better smg
-	gun_tags = list(GUN_PROJECTILE, GUN_SILENCABLE)
+	gun_tags = list(GUN_SILENCABLE)
 	recoil_buildup = 3
 	one_hand_penalty = 5 //despine it being handgun, it's better to hold in two hands while shooting. SMG level.
 

--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -21,7 +21,6 @@
 	damage_multiplier = 1.25
 	penetration_multiplier = 1.1
 	one_hand_penalty = 5 //bullpup rifle (this one is smaller and carbine, so it's 5)
-	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG, GUN_SOL)
 
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,
@@ -45,8 +44,6 @@
 	overlays.Cut()
 	update_charge()
 
-/obj/item/weapon/gun/projectile/automatic/sol/rds
-	desc = "A standard-issue weapon used by Aegis operatives. Compact and reliable. Uses .25 Caseless Rifle rounds. This one comes with red dot sight."
-	icon_state = "sol-eot"
-	price_tag = 2350
-	zoom_factor = 0.2
+/obj/item/weapon/gun/projectile/automatic/sol/generate_guntags()
+	..()
+	gun_tags |= GUN_SOL

--- a/code/modules/projectiles/guns/projectile/automatic/straylight.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/straylight.dm
@@ -22,7 +22,7 @@
 	penetration_multiplier = 0.5 //practically no AP, 2.5 with regular rounds and 5 with HV. Still deadly to unarmored targets.
 	recoil_buildup = 3
 	one_hand_penalty = 5 //smg level
-	gun_tags = list(GUN_PROJECTILE, GUN_SILENCABLE)
+	gun_tags = list(GUN_SILENCABLE)
 
 	init_firemodes = list(
 		FULL_AUTO_600,

--- a/code/modules/projectiles/guns/projectile/pistol/giskard.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/giskard.dm
@@ -6,6 +6,7 @@
 	item_state = "pistol"
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
 	gun_tags = list(GUN_SILENCABLE)
+	caliber = CAL_PISTOL
 	w_class = ITEM_SIZE_SMALL
 	can_dual = 1
 	fire_delay = 0.6

--- a/code/modules/projectiles/guns/projectile/pistol/handmade.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/handmade.dm
@@ -17,7 +17,6 @@
 	var/chamber_open = FALSE
 	var/jammed = FALSE
 	var/jam_chance = 15
-	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG, GUN_CALIBRE_35)
 
 /obj/item/weapon/gun/projectile/handmade_pistol/New()
 	..()

--- a/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
@@ -17,7 +17,6 @@
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.2
 	recoil_buildup = 6
-	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_35)
 	init_firemodes = list(
 		list(mode_name="semiauto",       burst=1, fire_delay=1.2, move_delay=null, 				icon="semi"),
 		list(mode_name="2-round bursts", burst=2, fire_delay=0.2, move_delay=4,    	icon="burst"),

--- a/code/modules/projectiles/guns/projectile/pistol/paco.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/paco.dm
@@ -22,7 +22,7 @@
 	damage_multiplier = 1.35
 	penetration_multiplier = 0.8
 	recoil_buildup = 20
-	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_35, GUN_SILENCABLE)
+	gun_tags = list(GUN_SILENCABLE)
 
 /obj/item/weapon/gun/projectile/paco/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/revolver/havelock.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/havelock.dm
@@ -16,4 +16,3 @@
 	damage_multiplier = 1.4 //because pistol round
 	penetration_multiplier = 1.4
 	recoil_buildup = 18
-	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_35)

--- a/code/modules/projectiles/guns/projectile/revolver/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/revolver.dm
@@ -60,3 +60,7 @@
 
 /obj/item/weapon/gun/projectile/revolver/update_icon()
 	update_charge()
+
+/obj/item/weapon/gun/projectile/revolver/generate_guntags()
+	..()
+	gun_tags |= GUN_REVOLVER

--- a/code/modules/projectiles/guns/projectile/shotgun/regulator.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/regulator.dm
@@ -15,4 +15,3 @@
 	recoil_buildup = 16
 	one_hand_penalty = 15 //full sized shotgun level
 	rarity_value = 20
-

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -23,7 +23,6 @@
 	var/item_suffix = ""
 	zoom_factor = 2.0
 	twohanded = TRUE
-	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG)
 
 /obj/item/weapon/gun/projectile/heavysniper/update_icon()
 	..()


### PR DESCRIPTION
## About The Pull Request

This PR is essentially a port of https://github.com/discordia-space/CEV-Eris/pull/4994, which we apparently missed, somehow. It mainly reduces the amount of copypasta present in guncode and makes it more object-oriented.

It fixes several bugs, including but not limited to:
1) Ergonomic grips not fitting on guns at all
2) Scopes not fitting on anything at all
3) The Giskard not counting as a projectile-firing weapon and thus being unable to install barrel mods

## Changelog
```changelog
fix: Gun tags have been fixed, meaning ergonomic grips and such should actually fit on guns now.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
