### PR TITLE
Randomizes the License point value for oldified disks.

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2766,6 +2766,7 @@
 #include "zzz_modular_syzygy\code\modules\mining\mineral_effect.dm"
 #include "zzz_modular_syzygy\code\modules\mob\living\carbon\human\species\station\station.dm"
 #include "zzz_modular_syzygy\code\modules\reagents\recipes.dm"
+#include "zzz_modular_syzygy\code\modules\scrap\oldificator.dm"
 #include "zzz_modular_syzygy\code\modules\sprite_accessories\_accessories_sprite.dm"
 #include "zzz_modular_syzygy\code\modules\sprite_accessories\_accessory_hair.dm"
 #include "zzz_modular_syzygy\prosthesis\prosthesis_brands.dm"

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -322,7 +322,7 @@
 	if (.)
 		if(prob(80))
 			if(license > -1)
-				license = rand(3, (license / 2))
+				license = rand(3, (license - 2))
 	/*
 /obj/effect/decal/mecha_wreckage/make_old()
 	.=..()

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -317,10 +317,20 @@
 		if(hud && prob(75))
 			hud = new /obj/item/clothing/glasses/hud/broken
 
-/*
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/make_old()
+	.=..()
+	if (.)
+		if(prob(80))
+			if(license > -1)
+				license = rand(3, (license / 2))
+		if(prob(90))
+			var/corrupted_item = pick(designs)
+			designs(corrupted_item) = /datum/design/autolathe/corrupted
+
+//			/datum/design/autolathe/corrupted
+	/*
 /obj/effect/decal/mecha_wreckage/make_old()
 	.=..()
 	if (.)
 		salvage_num = max(1, salvage_num - pick(1, 2, 3))
 */
-

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -320,9 +320,9 @@
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/make_old()
 	.=..()
 	if (.)
-		if(prob(80))
+		if(prob(90))
 			if(license > -1)
-				license = rand(3, (license - 2))
+				license = rand(3, (license - 3))
 	/*
 /obj/effect/decal/mecha_wreckage/make_old()
 	.=..()

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -325,7 +325,7 @@
 				if(license < 2)
 					license = rand(3, (license - 3))
 				else if ()
-				 	license = rand(0, 2)
+					license = rand(0, 2)
 //end szyzygy edit
 	/*
 /obj/effect/decal/mecha_wreckage/make_old()

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -316,16 +316,8 @@
 	if (.)
 		if(hud && prob(75))
 			hud = new /obj/item/clothing/glasses/hud/broken
-//szyzygy edit.
-/obj/item/weapon/computer_hardware/hard_drive/portable/design/make_old()
-	.=..()
-	if (.)
-		if(prob(90))
-			if(license > -1)
-				license = rand(3, (license - 3))
 
-//end szyzygy edit
-	/*
+/*
 /obj/effect/decal/mecha_wreckage/make_old()
 	.=..()
 	if (.)

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -322,10 +322,8 @@
 	if (.)
 		if(prob(90))
 			if(license > -1)
-				if(license < 2)
-					license = rand(3, (license - 3))
-				else ()
-					license = rand(0, 2)
+				license = rand(3, (license - 3))
+
 //end szyzygy edit
 	/*
 /obj/effect/decal/mecha_wreckage/make_old()

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -316,7 +316,7 @@
 	if (.)
 		if(hud && prob(75))
 			hud = new /obj/item/clothing/glasses/hud/broken
-
+//szyzygy edit.
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/make_old()
 	.=..()
 	if (.)
@@ -326,7 +326,7 @@
 					license = rand(3, (license - 3))
 				else if ()
 				 	license = rand(0, 2)
-
+//end szyzygy edit
 	/*
 /obj/effect/decal/mecha_wreckage/make_old()
 	.=..()

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -322,7 +322,11 @@
 	if (.)
 		if(prob(90))
 			if(license > -1)
-				license = rand(3, (license - 3))
+				if(license < 2)
+					license = rand(3, (license - 3))
+				else if ()
+				 	license = rand(0, 2)
+
 	/*
 /obj/effect/decal/mecha_wreckage/make_old()
 	.=..()

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -324,7 +324,7 @@
 			if(license > -1)
 				if(license < 2)
 					license = rand(3, (license - 3))
-				else if ()
+				else ()
 					license = rand(0, 2)
 //end szyzygy edit
 	/*

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -323,11 +323,6 @@
 		if(prob(80))
 			if(license > -1)
 				license = rand(3, (license / 2))
-		if(prob(90))
-			var/corrupted_item = pick(designs)
-			designs(corrupted_item) = /datum/design/autolathe/corrupted
-
-//			/datum/design/autolathe/corrupted
 	/*
 /obj/effect/decal/mecha_wreckage/make_old()
 	.=..()

--- a/zzz_modular_syzygy/code/modules/scrap/oldificator.dm
+++ b/zzz_modular_syzygy/code/modules/scrap/oldificator.dm
@@ -1,4 +1,4 @@
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/make_old()
 	.=..()
-		if(license > 0 && prob(90))
-			license = rand(3, (license - 3))
+	if(license > 0 && prob(90))
+		license = rand(3, (license - 3))

--- a/zzz_modular_syzygy/code/modules/scrap/oldificator.dm
+++ b/zzz_modular_syzygy/code/modules/scrap/oldificator.dm
@@ -1,6 +1,4 @@
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/make_old()
 	.=..()
-	if (.)
-		if(prob(90))
-			if(license > -1)
-				license = rand(3, (license - 3))
+		if(license > 0 && prob(90))
+			license = rand(3, (license - 3))

--- a/zzz_modular_syzygy/code/modules/scrap/oldificator.dm
+++ b/zzz_modular_syzygy/code/modules/scrap/oldificator.dm
@@ -1,0 +1,6 @@
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/make_old()
+	.=..()
+	if (.)
+		if(prob(90))
+			if(license > -1)
+				license = rand(3, (license - 3))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
All this does is add a specific oldification for the design disks that makes the disks have a 90% chance of having anywhere between 3 and 3 less than the maximum value of LP for any old disks.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Disks in the trash shouldn't have the full amount of license points. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
balance: Balances the old disks to not be as good as just a regular, untarnished disks, 

```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
