### PR TITLE
Cleaning fixes

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2770,6 +2770,7 @@
 #include "zzz_modular_syzygy\vote.dm"
 #include "zzz_modular_syzygy\wire_splicing.dm"
 #include "zzz_modular_syzygy\code\game\jobs\SZdepartment.dm"
+#include "zzz_modular_syzygy\code\game\objects\effects\decals\Cleanable\humans.dm"
 #include "zzz_modular_syzygy\code\game\objects\items\tools\_tools.dm"
 #include "zzz_modular_syzygy\code\modules\loot_spawn_blacklist.dm"
 #include "zzz_modular_syzygy\code\modules\economy\price_list_fixed.dm"

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -303,7 +303,11 @@
 			if(S.wet >= 2)
 				S.wet_floor(1, TRUE)
 		T.clean_blood()
-
+		//SYZYGY edit - Cleaning up decals properly too
+		for(var/obj/effect/O in T)
+			if(istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
+				qdel(O)
+		//end syzygy edit
 		for(var/mob/living/carbon/slime/M in T)
 			M.adjustToxLoss(rand(5, 10))
 
@@ -465,7 +469,7 @@
 					R.metabolism = initial(R.metabolism)
 					break
 
-/datum/reagent/other/arectine 
+/datum/reagent/other/arectine
 	name = "Arectine"
 	id = "arectine"
 	description = "Makes user emit light."

--- a/zzz_modular_syzygy/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/zzz_modular_syzygy/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -1,0 +1,5 @@
+/obj/effect/decal/cleanable/blood/gibs
+	icon_state = "mgibbl5"
+	random_icon_states = list("gib1", "gib2", "gib3", "gib5", "gib6")
+
+//Fix for missing iconstate


### PR DESCRIPTION
Fixes cleaner-based reagent reactions not properly qdel cleanable decals.
Fixes generic gibs having a missing iconstate (removed gib4 from the cleanable/gibs object)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes cleaner not removing cleanable decals (they were only hidden before)(proc. Could not be modularized)
Fixes a ref to a missing gib iconstate. (modular)

## Why It's Good For The Game

Bugfixes that legitimately make sanity gain/loss problematic in commonly dirtied areas. Invisible cleanable decals will tank your sanity without being well... visible.

## Changelog
```changelog
fix: Cleaner reactions work properly
fix: Gibs should no longer be invisible
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
