### PR TITLE
Autolathen nerfs

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2772,6 +2772,7 @@
 #include "zzz_modular_syzygy\code\game\jobs\SZdepartment.dm"
 #include "zzz_modular_syzygy\code\game\objects\effects\decals\Cleanable\humans.dm"
 #include "zzz_modular_syzygy\code\game\objects\items\tools\_tools.dm"
+#include "zzz_modular_syzygy\code\modules\autolathe.dm"
 #include "zzz_modular_syzygy\code\modules\loot_spawn_blacklist.dm"
 #include "zzz_modular_syzygy\code\modules\economy\ATM.dm"
 #include "zzz_modular_syzygy\code\modules\economy\price_list_fixed.dm"

--- a/code/datums/autolathe/autolathe_datums.dm
+++ b/code/datums/autolathe/autolathe_datums.dm
@@ -154,7 +154,7 @@
 
 //Returns a new instance of the item for this design
 //This is to allow additional initialization to be performed, including possibly additional contructor arguments.
-/datum/design/proc/Fabricate(newloc, mat_efficiency, fabricator)
+/datum/design/proc/Fabricate(newloc, mat_efficiency, fabricator, cheap_printer) //Syz edit
 	if(!build_path)
 		return
 
@@ -166,7 +166,8 @@
 			if(length(O.matter))
 				for(var/i in O.matter)
 					O.matter[i] = round(O.matter[i] * mat_efficiency, 0.01)
-
+	if(cheap_printer) //Syz edit
+		A.cheap_print() //Syz edit
 	return A
 
 /datum/design/autolathe

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -54160,7 +54160,7 @@
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/engineering/post)
 "cwW" = (
-/obj/machinery/autolathe/loaded,
+/obj/machinery/autolathe/advanced/loaded,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/quartermaster/storage)
 "cwZ" = (
@@ -79532,7 +79532,7 @@
 /obj/machinery/camera/network/engineering{
 	dir = 8
 	},
-/obj/machinery/autolathe/loaded,
+/obj/machinery/autolathe/advanced/loaded,
 /turf/simulated/floor/plating,
 /area/eris/engineering/construction)
 "dEj" = (

--- a/zzz_modular_syzygy/code/modules/autolathe.dm
+++ b/zzz_modular_syzygy/code/modules/autolathe.dm
@@ -4,7 +4,7 @@
 
 /obj/machinery/autolathe/advanced
 	name = "Advanced Autolathe"
-	desc = "It produces items using metal and glass. Unlike the normal this is an advanced verson with a micro laser for finner printing."
+	desc = "It produces items using metal and glass. Unlike the normal this is an advanced verson with a micro laser for faster printing."
 	cheap_printer = FALSE
 	circuit = /obj/item/weapon/electronics/circuitboard/autolathe_advanced
 

--- a/zzz_modular_syzygy/code/modules/autolathe.dm
+++ b/zzz_modular_syzygy/code/modules/autolathe.dm
@@ -2,6 +2,35 @@
 /obj/machinery/autolathe
 	var/cheap_printer = TRUE //Used for printed less affective guns/tools
 
+/obj/machinery/autolathe/advanced
+	name = "Advanced Autolathe"
+	desc = "It produces items using metal and glass. Unlike the normal this is an advanced verson with a micro laser for finner printing."
+	cheap_printer = FALSE
+	circuit = /obj/item/weapon/electronics/circuitboard/autolathe_advanced
+
+/obj/machinery/autolathe/advanced/loaded
+	stored_material = list(
+		MATERIAL_STEEL = 60,
+		MATERIAL_PLASTIC = 60,
+		MATERIAL_GLASS = 60,
+		)
+
+/obj/machinery/autolathe/advanced/loaded/Initialize()
+	. = ..()
+	container = new /obj/item/weapon/reagent_containers/glass/beaker(src)
+
+/obj/item/weapon/electronics/circuitboard/autolathe_advanced
+	name = T_BOARD("autolathe")
+	build_path = /obj/machinery/autolathe/advanced
+	board_type = "machine"
+	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)
+	req_components = list(
+		/obj/item/weapon/stock_parts/matter_bin = 3,
+		/obj/item/weapon/stock_parts/manipulator = 1,
+		/obj/item/weapon/stock_parts/micro_laser = 1,
+		/obj/item/weapon/stock_parts/console_screen = 1,
+	)
+
 /obj/machinery/autolathe/rnd
 	cheap_printer = FALSE
 

--- a/zzz_modular_syzygy/code/modules/autolathe.dm
+++ b/zzz_modular_syzygy/code/modules/autolathe.dm
@@ -1,0 +1,32 @@
+
+/obj/machinery/autolathe
+	var/cheap_printer = TRUE //Used for printed less affective guns/tools
+
+/obj/machinery/autolathe/rnd
+	cheap_printer = FALSE
+
+/obj/machinery/autolathe/excelsior
+	cheap_printer = FALSE
+
+/obj/machinery/autolathe/bioprinter
+	cheap_printer = FALSE
+
+/obj/machinery/autolathe/mechfab
+	cheap_printer = FALSE
+
+/atom/proc/cheap_print()
+	return
+
+/obj/item/weapon/tool/cheap_print()
+	.=..()
+	if(.)
+		precision -= 5
+		workspeed = workspeed-0.05 //So we lose 5% of seed
+		degradation += 5
+		health = rand(10, max_health)
+
+/obj/item/weapon/gun/cheap_print()
+	. = ..()
+	fire_delay+= 1
+	recoil_buildup+= 4
+


### PR DESCRIPTION
## About The Pull Request

> FishYesterday at 7:29 PM
> Uh, I meant-
> [7:29 PM]
> A consistent oldification that makes them 15% worse across the board
> [7:29 PM]
> not subtypes
> [7:29 PM]
> It's high end machinery, it makes a consistent product
> [7:30 PM]
> it's just not a particularly good product

New autolathe type that has not of this nerf but a buff! To print faster with a normal micro laser.
Hard to fine the boards if at all possable.

Does this. **_Maybe its untested code_**

## Why It's Good For The Game

Should help make people want to scav or buy better tools from venders/cargo/players rather then getting a disk and making it

Does not affect the Cargo or engi autolathen for the nerfs as they are meant to print these things

## Changelog
```changelog
add: New autolathe type that has not of this nerf but a buff! To print faster with a normal micro laser.
balance: Basic Autolathens will now print things like tools and guns slightly less affective then buying from a vender or other crew member.
```
