### PR TITLE
pricing adjustments

### DIFF
--- a/zzz_modular_syzygy/code/modules/economy/price_list_fixed.dm
+++ b/zzz_modular_syzygy/code/modules/economy/price_list_fixed.dm
@@ -455,3 +455,5 @@
 	. = ..()
 	for(var/datum/reagent/R in reagents.reagent_list)
 		. += R.volume * R.price_tag
+/obj/item/weapon/tool/price_tag = 5 //THIS IS MULTIPLIED BY (TOTAL TOOL_QUALITIES/5+1)
+/obj/item/ammo_casing/price_tag = 2


### PR DESCRIPTION
Fixed tools exporting for 30x their material costs.
Fixed ammo casings exporting for 20cr a pop.

## Why It's Good For The Game

Makes tools and ammo slightly less stupidly profitable when exporting.

## Changelog
```changelog
tweak: adjusted ammo and tool prices.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
