### PR TITLE
Nerfed Autolathe recycling

### DIFF
--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -264,8 +264,9 @@
 	usr.set_machine(src)
 
 	if(href_list["insert"])
-		eat(usr)
-		return 1
+		if(istype(usr.get_active_hand(), /obj/item/stack) || istype(usr.get_active_hand(), /obj/item/trash) || istype(usr.get_active_hand(), /obj/item/weapon/material/shard)) //SYZYGY Edit: Prevent new NanouUI function from bypassing scrap code for lathes.
+			eat(usr)
+			return 1
 
 	if(href_list["disk"])
 		if(disk)

--- a/code/game/machinery/smelter.dm
+++ b/code/game/machinery/smelter.dm
@@ -241,7 +241,7 @@
 		ml_rating += ML.rating
 		++ml_count
 
-	scrap_multiplier = initial(scrap_multiplier)+(((ml_rating/ml_count)-1)*0.05)
+	scrap_multiplier = initial(scrap_multiplier)+(((ml_rating/ml_count)-1)*0.15)//SYZYGY Edit - Boosts smelter to 25/40/55/70/85/100% effeciency based on the laser. Max reachable tier is 55% in normal play.
 
 	var/mb_rating = 0
 	var/mb_count = 0

--- a/zzz_modular_syzygy/code/modules/economy/price_list_fixed.dm
+++ b/zzz_modular_syzygy/code/modules/economy/price_list_fixed.dm
@@ -455,3 +455,5 @@
 	. = ..()
 	for(var/datum/reagent/R in reagents.reagent_list)
 		. += R.volume * R.price_tag
+/obj/item/weapon/tool/price_tag = 5 //THIS IS MULTIPLIED BY (TOTAL TOOL_QUALITIES/5+1)
+/obj/item/ammo_casing/price_tag = 2

--- a/zzz_modular_syzygy/code/modules/economy/price_list_fixed.dm
+++ b/zzz_modular_syzygy/code/modules/economy/price_list_fixed.dm
@@ -455,5 +455,3 @@
 	. = ..()
 	for(var/datum/reagent/R in reagents.reagent_list)
 		. += R.volume * R.price_tag
-/obj/item/weapon/tool/price_tag = 5 //THIS IS MULTIPLIED BY (TOTAL TOOL_QUALITIES/5+1)
-/obj/item/ammo_casing/price_tag = 2


### PR DESCRIPTION
### About The Pull Request

Removes ability for autolathe to eat stuff 
Buffs improved smelter from 25/30/35/40/45/50% efficiency to 25/40/55/70/85/100% efficiency 

## Why It's Good For The Game

Fewer mats from maint. Less access to rare mats outside of cargo. More reasons for sci to upgrade cargo. Less proliferation of high-end printed equipment.

It's a painful change, but a really necessary one. Autolathes should not be better at recycling than a dedicated smelter.
This also encourages people to go to cargo with scrap rather than hoarding it.

## Changelog
```changelog
balance: autolathes can no longer recycle anything at 100% efficiency
balance: buffed smelter recycling rate when upgraded from 5% per tier to 15% per tier.
```

...

I am sorry.
