### PR TITLE
Update price_list_fixed.dm

### DIFF
--- a/zzz_modular_syzygy/code/modules/economy/price_list_fixed.dm
+++ b/zzz_modular_syzygy/code/modules/economy/price_list_fixed.dm
@@ -455,3 +455,8 @@
 	. = ..()
 	for(var/datum/reagent/R in reagents.reagent_list)
 		. += R.volume * R.price_tag
+		
+/obj/item/weapon/tool/
+	price_tag = 5 //THIS IS MULTIPLIED BY (TOTAL TOOL_QUALITIES/5+1)
+/obj/item/ammo_casing/
+	price_tag = 2


### PR DESCRIPTION
This got accidentally overwritten during the last set of PRs

## About The Pull Request

Fixed the price of ammo and tools to a reasonable level

## Why It's Good For The Game

This was already merged and accidentally overwritten
