### PR TITLE
Cherry picks an optimization PR from upstream

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -140,6 +140,7 @@
 	var/slowdown = 0              // Passive movement speed malus (or boost, if negative)
 	var/primitive_form            // Lesser form, if any (ie. monkey for humans)
 	var/greater_form              // Greater form, if any, ie. human for monkeys.
+	var/lower_sanity_process	  // Controls how much sanity is processed on the mob for performance reasons.
 	var/holder_type
 	var/gluttonous                // Can eat some mobs. Values can be GLUT_TINY, GLUT_SMALLER, GLUT_ANYTHING.
 	var/species_rarity_value = 1          // Relative rarity/collector value for this species.

--- a/code/modules/mob/living/carbon/human/species/station/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/station/monkey.dm
@@ -31,6 +31,7 @@
 	total_health = 75
 	brute_mod = 1.5
 	burn_mod = 1.5
+	lower_sanity_process = TRUE
 
 	spawn_flags = IS_RESTRICTED
 

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -64,7 +64,6 @@
 	var/view_damage_threshold = 20
 	var/environment_cap_coeff = 1 //How much we are affected by environmental cognitohazards. Multiplies the above threshold
 
-
 	var/say_time = 0
 	var/breakdown_time = 0
 	var/spook_time = 0
@@ -75,6 +74,8 @@
 
 	var/eat_time_message = 0
 
+	var/life_tick_modifier = 2	//How often is the onLife() triggered and by how much are the effects multiplied
+
 /datum/sanity/New(mob/living/carbon/human/H)
 	owner = H
 	level = max_level
@@ -83,7 +84,8 @@
 	RegisterSignal(owner, COMSIG_HUMAN_SAY, .proc/onSay)
 
 /datum/sanity/proc/onLife()
-	if(owner.stat == DEAD || owner.in_stasis)
+	handle_breakdowns()
+	if(owner.stat == DEAD || owner.life_tick % life_tick_modifier || owner.in_stasis || (owner.species.lower_sanity_process && !owner.client))
 		return
 	var/affect = SANITY_PASSIVE_GAIN * sanity_passive_gain_multiplier
 	if(owner.stat) //If we're unconscious
@@ -92,8 +94,7 @@
 	if(!(owner.sdisabilities & BLIND) && !owner.blinded)
 		affect += handle_area()
 		affect -= handle_view()
-	changeLevel(max(affect, min((view_damage_threshold*environment_cap_coeff) - level, 0)))
-	handle_breakdowns()
+	changeLevel(max(affect  * life_tick_modifier, min((view_damage_threshold*environment_cap_coeff) - level, 0)))
 	handle_insight()
 	handle_level()
 
@@ -132,7 +133,7 @@
 			if(H)
 				if(H.sanity.level > 60)
 					moralist_factor += 0.02
-	insight += INSIGHT_GAIN(level_change) * insight_passive_gain_multiplier * moralist_factor * style_factor
+	insight += INSIGHT_GAIN(level_change) * insight_passive_gain_multiplier * moralist_factor * style_factor * life_tick_modifier
 	while(insight >= 100)
 		to_chat(owner, SPAN_NOTICE("You have gained insight.[resting ? null : " Now you need to rest and rethink your life choices."]"))
 		owner.playsound_local(get_turf(owner), 'sound/sanity/psychochimes.ogg', 100)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR cherry picks https://github.com/discordia-space/CEV-Eris/pull/5635, which makes monkeys stop processing environmental sanity factors and drastically reduces the amount of resources they hog up, which should make the server run better. _In theory_.

I've compiled it successfully and it doesn't throw any runtimes when tested, but I don't have enough COG to interpret the profiler results to tell how good the optimizations are.

## Why It's Good For The Game

Optimizations good.

## Changelog
```changelog CEV-Eris Developers
tweak: NPC monkeys don't receive environment sanity damage and insight.
code: onLife() sanity procs effects trigger once every 2 life ticks.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
