### PR TITLE
Proper Autolathe Recycling Nerf

### DIFF
--- a/code/game/machinery/excelsior/autolathe.dm
+++ b/code/game/machinery/excelsior/autolathe.dm
@@ -10,6 +10,8 @@
 	storage_capacity = 240
 	unsuitable_materials = list()	// Can use biomatter too.
 
+	recycle_multiplier = 0.30	//SYZYGY EDIT - Innately higher recyling efficiency
+
 /obj/machinery/autolathe/excelsior/Initialize()
 	. = ..()
 	container = new /obj/item/weapon/reagent_containers/glass/beaker/large(src)

--- a/code/game/machinery/smelter.dm
+++ b/code/game/machinery/smelter.dm
@@ -29,7 +29,7 @@
 	var/forbidden_materials = list(MATERIAL_CARDBOARD,MATERIAL_WOOD,MATERIAL_BIOMATTER)
 
 	// base multiplier for scrap smelting, increased by better microlasers
-	var/scrap_multiplier = 0.25
+	var/scrap_multiplier = 0.30	//SYZYGY EDIT - Slight buff
 
 	//some UI stuff here
 	var/show_config = FALSE
@@ -122,6 +122,8 @@
 			if(istype(smelting,/obj/item/stack))
 				var/obj/item/stack/material/S = smelting
 				total_material *= S.get_amount()
+
+			total_material *= scrap_multiplier	//	Syzygy edit - Nerfs recycling
 
 			stored_material[material] += total_material
 
@@ -241,7 +243,7 @@
 		ml_rating += ML.rating
 		++ml_count
 
-	scrap_multiplier = initial(scrap_multiplier)+(((ml_rating/ml_count)-1)*0.15)//SYZYGY Edit - Boosts smelter to 25/40/55/70/85/100% effeciency based on the laser. Max reachable tier is 55% in normal play.
+	scrap_multiplier = clamp(initial(scrap_multiplier)+(((ml_rating/ml_count)-1)*0.15), 0, 1)	//SYZYGY Edit - Boosts smelter to 30/45/60/75/90/100% effeciency based on the laser. Max reachable tier is 60% in normal play.
 
 	var/mb_rating = 0
 	var/mb_count = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes it such that regular autolathes only recover 25% of the material from a recycled item, by default. Upgrading with pico manipulators sets them to 55%. Excelsior lathes and the Smelter have been buffed to 30% at base, still capping out at 100% with Xenoarch parts. No violating conservation of mass here.

## Why It's Good For The Game

This is so much better than straight out disabling autolathe recycling.

## Changelog
```changelog Toriate
add: Autolathe recycling has been re-enabled, but with only 25% efficiency. Pico manipulators give them 55% efficiency. Xenoarcheology is required to max them out to 100%.
tweak: Excelsior lathe and Smelter have received 5% extra recycling efficiency at base. Still caps out at 100%.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
