### PR TITLE
Pipe Dispeser, Disposal Dispenser, and Bar table fixes

### DIFF
--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -7,8 +7,8 @@
 	var/wait = 0
 
 /obj/machinery/pipedispenser/attack_hand(user as mob)
-	if(..())
-		return
+//	if(..()) SYZYGY EDIT - THIS BREAKS DISPENSERS
+//		return SYZYGY EDIT - THIS BREAKS DISPENSERS
 ///// Z-Level stuff
 	var/dat = {"
 <b>Regular pipes:</b><BR>
@@ -152,8 +152,8 @@ Nah
 	qdel(pipe)
 
 /obj/machinery/pipedispenser/disposal/attack_hand(user as mob)
-	if(..())
-		return
+//	if(..()) SYZYGY EDIT - THIS BREAKS DISPENSERS
+//		return SYZYGY EDIT - THIS BREAKS DISPENSERS
 
 ///// Z-Level stuff
 	var/dat = {"<b>Disposal Pipes</b><br><br>

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -135,9 +135,9 @@ var/list/custom_table_appearance = list(
 
 		if(QUALITY_PRYING)
 			if(custom_appearance)
-				if(custom_appearance[5] && !reinforced)
+				/*if(custom_appearance[5] && !reinforced) SYZYGY Edit - This was preventing people from modifying the bar tables at all. Fixed!
 					to_chat(user, SPAN_WARNING("This type of design can't be applied to simple tables. Reinforce it first."))
-					return
+					return*/
 				if(I.use_tool(user, src, WORKTIME_NORMAL, tool_type, FAILCHANCE_EASY,  required_stat = STAT_MEC))
 					user.visible_message(
 						SPAN_NOTICE("\The [user] removes the carpet from \the [src]."),

--- a/zzz_modular_syzygy/code/modules/economy/price_list_fixed.dm
+++ b/zzz_modular_syzygy/code/modules/economy/price_list_fixed.dm
@@ -455,3 +455,8 @@
 	. = ..()
 	for(var/datum/reagent/R in reagents.reagent_list)
 		. += R.volume * R.price_tag
+		
+/obj/item/weapon/tool/
+	price_tag = 5 //THIS IS MULTIPLIED BY (TOTAL TOOL_QUALITIES/5+1)
+/obj/item/ammo_casing/
+	price_tag = 2


### PR DESCRIPTION
t## About The Pull Request

Fixed UI on Pipe dispensers, disposal dispensers
Fixes custom appearance tables from being moved. Apply crowbar to remove the carpet.

## Why It's Good For The Game
Bug fixes

## Changelog
```changelog
fix: fixed pipe dispenser UI
fix: fixed disposal dispenser UI
fix: fixed custom tables being unable to be deconstructed
```

This needs to be merged AFTER the price fix PR. I apologize for the sloppy git trail.
