### PR TITLE
Defib Timer Tweaks, Spawnpoint Bugfixes

### DIFF
--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -142,7 +142,7 @@
 	setup_restricted = TRUE
 
 /obj/landmark/join/start/hydro
-	name = "NeoTheology Agrolyte"
+	name = "Mekhane Agrolyte"	//SYZYGY EDIT - Fixes landmarks
 	icon_state = "player-black"
 	join_tag = /datum/job/hydro
 
@@ -182,6 +182,6 @@
 	setup_restricted = TRUE
 
 /obj/landmark/join/start/janitor
-	name = "NeoTheology Custodian"
+	name = "Mekhane Custodian"	//SYZYGY EDIT - Fixes landmarks
 	icon_state = "player-black"
 	join_tag = /datum/job/janitor

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -125,6 +125,6 @@ The Northern Light is your home, your life, and your livelihood. Take pride in i
 	perks = list(/datum/perk/inspiration)
 
 /obj/landmark/join/start/technomancer
-	name = "Engineer"
+	name = "Ship Engineer"	//SYZYGY EDIT - Fixes landmarks
 	icon_state = "player-orange"
 	join_tag = /datum/job/technomancer

--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -54,7 +54,7 @@ Your second loyalty is to the Union. Ensure it retains good relations with priva
 	outfit_type = /decl/hierarchy/outfit/job/cargo/merchant
 
 /obj/landmark/join/start/merchant
-	name = "Trade Union Merchant"
+	name = "Free Trade Union Merchant"	//SYZYGY EDIT - Fixes landmarks
 	icon_state = "player-beige-officer"
 	join_tag = /datum/job/merchant
 
@@ -108,7 +108,7 @@ Your main duties are to keep the local Union branch operational and profitable. 
 		Your second loyalty is to the merchant, he ensures you're well paid and respected, in a universe where workers are often treated as interchangeable parts."
 
 /obj/landmark/join/start/cargo_tech
-	name = "Union Technician"
+	name = "Union Cargo Technician"	//SYZYGY EDIT - Fixes landmarks
 	icon_state = "player-beige"
 	join_tag = /datum/job/cargo_tech
 

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -280,7 +280,7 @@
 		Your third loyalty is to humanity. You are still human under all that armour. If you're being ordered to slaughter civilians en masse, it may be time to start thinking for yourself."
 
 /obj/landmark/join/start/ihoper
-	name = "Cobalt Operative"
+	name = "Aegis Operative"	//SYZYGY EDIT - Fixes landmarks
 	icon_state = "player-blue"
 	join_tag = /datum/job/ihoper
 

--- a/zzz_modular_syzygy/defib.dm
+++ b/zzz_modular_syzygy/defib.dm
@@ -1,4 +1,4 @@
-#define DEFIB_TIME_LIMIT (10 MINUTES) //past this many seconds, defib is useless.
+#define DEFIB_TIME_LIMIT (15 MINUTES) //past this many seconds, defib is useless.
 #define DEFIB_TIME_LOSS  (2 MINUTES) //past this many seconds, brain damage occurs.
 
 /*	brain tickers broke


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR will set the defib timer back to 15 minutes, as well as fix the glaring issue with dysfunctional roundstart spawnpoint landmarks. Engineers most notably get to spawn properly again.

Closes #236 
## Changelog
```changelog Toriate
tweak: Defib timer is now 15 minutes again, as it was
fix: Roundstart spawnpoints should now function again, instead of randomly dumping you in maintenance
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
